### PR TITLE
Add helper accessors to structs

### DIFF
--- a/internal/client-gen/api/field_type.go
+++ b/internal/client-gen/api/field_type.go
@@ -16,16 +16,16 @@ package api
 
 var (
 	Boolean = FieldType{
-		fieldTypeImpl: primitiveFieldType{kind: "bool"},
+		fieldTypeImpl: primitiveFieldType{kind: "bool", defaultValue: "false"},
 	}
 	Decimal = FieldType{
-		fieldTypeImpl: primitiveFieldType{kind: "float64"},
+		fieldTypeImpl: primitiveFieldType{kind: "float64", defaultValue: "0"},
 	}
 	Number = FieldType{
-		fieldTypeImpl: primitiveFieldType{kind: "int64"},
+		fieldTypeImpl: primitiveFieldType{kind: "int64", defaultValue: "0"},
 	}
 	String = FieldType{
-		fieldTypeImpl: primitiveFieldType{kind: "string"},
+		fieldTypeImpl: primitiveFieldType{kind: "string", defaultValue: `""`},
 	}
 
 	UnknownType = FieldType{
@@ -38,9 +38,7 @@ type fieldTypeImpl interface {
 	// GoType is the Golang type definition.
 	GoType() string
 
-	// // IsObjectType indicates whether the type is a Golang struct.
-	// // TODO: (jtoyer) Add information about how to get the object definition
-	// IsObjectType() bool
+	DefaultValue() string
 }
 
 // FieldType represents the derived type from the API specification for a field on an endpoint object.
@@ -52,6 +50,12 @@ type FieldType struct {
 // expected for the list.
 func (t FieldType) IsListType() bool {
 	_, ok := t.fieldTypeImpl.(listFieldType)
+	return ok
+}
+
+// IsObjectType indicates whether the type is a Golang struct.
+func (t FieldType) IsObjectType() bool {
+	_, ok := t.fieldTypeImpl.(objectFieldType)
 	return ok
 }
 
@@ -76,11 +80,16 @@ func (t FieldType) String() string {
 }
 
 type primitiveFieldType struct {
-	kind string
+	defaultValue string
+	kind         string
 }
 
 func (t primitiveFieldType) GoType() string {
 	return t.kind
+}
+
+func (t primitiveFieldType) DefaultValue() string {
+	return t.defaultValue
 }
 
 type listFieldType struct {
@@ -89,6 +98,10 @@ type listFieldType struct {
 
 func (t listFieldType) GoType() string {
 	return "[]" + t.elementType.GoType()
+}
+
+func (t listFieldType) DefaultValue() string {
+	return "nil"
 }
 
 func List(element FieldType) FieldType {
@@ -103,6 +116,10 @@ type objectFieldType struct {
 
 func (t objectFieldType) GoType() string {
 	return t.kind
+}
+
+func (t objectFieldType) DefaultValue() string {
+	return "nil"
 }
 
 func Object(name string) FieldType {

--- a/internal/client-gen/api/templates/struct.gotmpl
+++ b/internal/client-gen/api/templates/struct.gotmpl
@@ -1,5 +1,18 @@
 type {{ .Name }} struct {
 	{{- range $field := .Fields }}
-	{{ $field.Name }} *{{ $field.Type }} `json:"{{ $field.JSONName}},omitempty"`
+	{{ $field.Name }} *{{ $field.Type.GoType }} `json:"{{ $field.JSONName}},omitempty"`
 	{{- end }}
 }
+{{ range $field := .Fields }}
+func (s *{{ $.Name }}) Get{{ $field.Name }}() {{ if $field.Type.IsObjectType }}*{{ end }}{{ $field.Type }} {
+	if s == nil {{ if not $field.Type.IsPrimitiveType }}|| s.{{ $field.Name}} == nil {{ end }}{
+		return {{ $field.Type.DefaultValue }}
+	}
+
+	{{ if $field.Type.IsObjectType -}}
+	return s.{{ $field.Name }}
+	{{- else -}}
+	return *s.{{ $field.Name }}
+	{{- end }}
+}
+{{ end -}}

--- a/networkserver/account.generated.go
+++ b/networkserver/account.generated.go
@@ -27,3 +27,67 @@ type Account struct {
 	Vlan             *int64  `json:"vlan,omitempty"`
 	XPassword        *string `json:"x_password,omitempty"`
 }
+
+func (s *Account) GetIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ip
+}
+
+func (s *Account) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *Account) GetNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NetworkconfId
+}
+
+func (s *Account) GetTunnelConfigType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.TunnelConfigType
+}
+
+func (s *Account) GetTunnelMediumType() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.TunnelMediumType
+}
+
+func (s *Account) GetTunnelType() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.TunnelType
+}
+
+func (s *Account) GetVlan() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Vlan
+}
+
+func (s *Account) GetXPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XPassword
+}

--- a/networkserver/broadcast_group.generated.go
+++ b/networkserver/broadcast_group.generated.go
@@ -21,3 +21,19 @@ type BroadcastGroup struct {
 	MemberTable *[]string `json:"member_table,omitempty"`
 	Name        *string   `json:"name,omitempty"`
 }
+
+func (s *BroadcastGroup) GetMemberTable() []string {
+	if s == nil || s.MemberTable == nil {
+		return nil
+	}
+
+	return *s.MemberTable
+}
+
+func (s *BroadcastGroup) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}

--- a/networkserver/channel_plan.generated.go
+++ b/networkserver/channel_plan.generated.go
@@ -31,16 +31,152 @@ type ChannelPlan struct {
 	SiteBlacklistedChannels *[]ChannelPlanSiteBlacklistedChannels `json:"site_blacklisted_channels,omitempty"`
 }
 
+func (s *ChannelPlan) GetApBlacklistedChannels() []ChannelPlanApBlacklistedChannels {
+	if s == nil || s.ApBlacklistedChannels == nil {
+		return nil
+	}
+
+	return *s.ApBlacklistedChannels
+}
+
+func (s *ChannelPlan) GetConfSource() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ConfSource
+}
+
+func (s *ChannelPlan) GetCoupling() []ChannelPlanCoupling {
+	if s == nil || s.Coupling == nil {
+		return nil
+	}
+
+	return *s.Coupling
+}
+
+func (s *ChannelPlan) GetDate() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Date
+}
+
+func (s *ChannelPlan) GetFitness() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Fitness
+}
+
+func (s *ChannelPlan) GetNote() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Note
+}
+
+func (s *ChannelPlan) GetRadio() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Radio
+}
+
+func (s *ChannelPlan) GetRadioTable() []ChannelPlanRadioTable {
+	if s == nil || s.RadioTable == nil {
+		return nil
+	}
+
+	return *s.RadioTable
+}
+
+func (s *ChannelPlan) GetSatisfaction() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Satisfaction
+}
+
+func (s *ChannelPlan) GetSatisfactionTable() []ChannelPlanSatisfactionTable {
+	if s == nil || s.SatisfactionTable == nil {
+		return nil
+	}
+
+	return *s.SatisfactionTable
+}
+
+func (s *ChannelPlan) GetSiteBlacklistedChannels() []ChannelPlanSiteBlacklistedChannels {
+	if s == nil || s.SiteBlacklistedChannels == nil {
+		return nil
+	}
+
+	return *s.SiteBlacklistedChannels
+}
+
 type ChannelPlanApBlacklistedChannels struct {
 	Channel   *float64 `json:"channel,omitempty"`
 	Mac       *string  `json:"mac,omitempty"`
 	Timestamp *int64   `json:"timestamp,omitempty"`
 }
 
+func (s *ChannelPlanApBlacklistedChannels) GetChannel() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Channel
+}
+
+func (s *ChannelPlanApBlacklistedChannels) GetMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Mac
+}
+
+func (s *ChannelPlanApBlacklistedChannels) GetTimestamp() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Timestamp
+}
+
 type ChannelPlanCoupling struct {
 	Rssi   *int64  `json:"rssi,omitempty"`
 	Source *string `json:"source,omitempty"`
 	Target *string `json:"target,omitempty"`
+}
+
+func (s *ChannelPlanCoupling) GetRssi() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Rssi
+}
+
+func (s *ChannelPlanCoupling) GetSource() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Source
+}
+
+func (s *ChannelPlanCoupling) GetTarget() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Target
 }
 
 type ChannelPlanRadioTable struct {
@@ -53,12 +189,100 @@ type ChannelPlanRadioTable struct {
 	Width         *int64  `json:"width,omitempty"`
 }
 
+func (s *ChannelPlanRadioTable) GetBackupChannel() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.BackupChannel
+}
+
+func (s *ChannelPlanRadioTable) GetChannel() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Channel
+}
+
+func (s *ChannelPlanRadioTable) GetDeviceMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DeviceMac
+}
+
+func (s *ChannelPlanRadioTable) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *ChannelPlanRadioTable) GetTxPower() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.TxPower
+}
+
+func (s *ChannelPlanRadioTable) GetTxPowerMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.TxPowerMode
+}
+
+func (s *ChannelPlanRadioTable) GetWidth() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Width
+}
+
 type ChannelPlanSatisfactionTable struct {
 	DeviceMac    *string `json:"device_mac,omitempty"`
 	Satisfaction *string `json:"satisfaction,omitempty"`
 }
 
+func (s *ChannelPlanSatisfactionTable) GetDeviceMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DeviceMac
+}
+
+func (s *ChannelPlanSatisfactionTable) GetSatisfaction() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Satisfaction
+}
+
 type ChannelPlanSiteBlacklistedChannels struct {
 	Channel   *float64 `json:"channel,omitempty"`
 	Timestamp *int64   `json:"timestamp,omitempty"`
+}
+
+func (s *ChannelPlanSiteBlacklistedChannels) GetChannel() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Channel
+}
+
+func (s *ChannelPlanSiteBlacklistedChannels) GetTimestamp() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Timestamp
 }

--- a/networkserver/dashboard.generated.go
+++ b/networkserver/dashboard.generated.go
@@ -25,9 +25,81 @@ type Dashboard struct {
 	Name              *string             `json:"name,omitempty"`
 }
 
+func (s *Dashboard) GetControllerVersion() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ControllerVersion
+}
+
+func (s *Dashboard) GetDesc() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Desc
+}
+
+func (s *Dashboard) GetIsPublic() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IsPublic
+}
+
+func (s *Dashboard) GetModules() []DashboardModules {
+	if s == nil || s.Modules == nil {
+		return nil
+	}
+
+	return *s.Modules
+}
+
+func (s *Dashboard) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
 type DashboardModules struct {
 	Config       *string `json:"config,omitempty"`
 	Id           *string `json:"id,omitempty"`
 	ModuleId     *string `json:"module_id,omitempty"`
 	Restrictions *string `json:"restrictions,omitempty"`
+}
+
+func (s *DashboardModules) GetConfig() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Config
+}
+
+func (s *DashboardModules) GetId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Id
+}
+
+func (s *DashboardModules) GetModuleId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ModuleId
+}
+
+func (s *DashboardModules) GetRestrictions() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Restrictions
 }

--- a/networkserver/device.generated.go
+++ b/networkserver/device.generated.go
@@ -96,6 +96,614 @@ type Device struct {
 	Y                           *string                    `json:"y,omitempty"`
 }
 
+func (s *Device) GetAtfEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.AtfEnabled
+}
+
+func (s *Device) GetBandsteeringMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.BandsteeringMode
+}
+
+func (s *Device) GetBaresipAuthUser() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.BaresipAuthUser
+}
+
+func (s *Device) GetBaresipEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.BaresipEnabled
+}
+
+func (s *Device) GetBaresipExtension() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.BaresipExtension
+}
+
+func (s *Device) GetConfigNetwork() *DeviceConfigNetwork {
+	if s == nil || s.ConfigNetwork == nil {
+		return nil
+	}
+
+	return s.ConfigNetwork
+}
+
+func (s *Device) GetDisabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Disabled
+}
+
+func (s *Device) GetDot1XFallbackNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dot1XFallbackNetworkconfId
+}
+
+func (s *Device) GetDot1XPortctrlEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Dot1XPortctrlEnabled
+}
+
+func (s *Device) GetDpiEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DpiEnabled
+}
+
+func (s *Device) GetEtherLighting() *DeviceEtherLighting {
+	if s == nil || s.EtherLighting == nil {
+		return nil
+	}
+
+	return s.EtherLighting
+}
+
+func (s *Device) GetEthernetOverrides() []DeviceEthernetOverrides {
+	if s == nil || s.EthernetOverrides == nil {
+		return nil
+	}
+
+	return *s.EthernetOverrides
+}
+
+func (s *Device) GetFlowctrlEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.FlowctrlEnabled
+}
+
+func (s *Device) GetGatewayVrrpMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.GatewayVrrpMode
+}
+
+func (s *Device) GetGatewayVrrpPriority() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.GatewayVrrpPriority
+}
+
+func (s *Device) GetGreenApEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.GreenApEnabled
+}
+
+func (s *Device) GetHeightInMeters() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.HeightInMeters
+}
+
+func (s *Device) GetHostname() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Hostname
+}
+
+func (s *Device) GetJumboframeEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.JumboframeEnabled
+}
+
+func (s *Device) GetLcmBrightness() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LcmBrightness
+}
+
+func (s *Device) GetLcmBrightnessOverride() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LcmBrightnessOverride
+}
+
+func (s *Device) GetLcmIdleTimeout() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LcmIdleTimeout
+}
+
+func (s *Device) GetLcmIdleTimeoutOverride() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LcmIdleTimeoutOverride
+}
+
+func (s *Device) GetLcmNightModeBegins() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LcmNightModeBegins
+}
+
+func (s *Device) GetLcmNightModeEnds() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LcmNightModeEnds
+}
+
+func (s *Device) GetLcmOrientationOverride() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LcmOrientationOverride
+}
+
+func (s *Device) GetLcmSettingsRestrictedAccess() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LcmSettingsRestrictedAccess
+}
+
+func (s *Device) GetLcmTrackerEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LcmTrackerEnabled
+}
+
+func (s *Device) GetLcmTrackerSeed() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LcmTrackerSeed
+}
+
+func (s *Device) GetLedOverride() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LedOverride
+}
+
+func (s *Device) GetLedOverrideColor() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LedOverrideColor
+}
+
+func (s *Device) GetLedOverrideColorBrightness() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LedOverrideColorBrightness
+}
+
+func (s *Device) GetLocked() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Locked
+}
+
+func (s *Device) GetLowpfmodeOverride() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LowpfmodeOverride
+}
+
+func (s *Device) GetLteApn() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LteApn
+}
+
+func (s *Device) GetLteAuthType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LteAuthType
+}
+
+func (s *Device) GetLteDataLimitEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LteDataLimitEnabled
+}
+
+func (s *Device) GetLteDataWarningEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LteDataWarningEnabled
+}
+
+func (s *Device) GetLteExtAnt() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LteExtAnt
+}
+
+func (s *Device) GetLteHardLimit() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LteHardLimit
+}
+
+func (s *Device) GetLtePassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LtePassword
+}
+
+func (s *Device) GetLtePoe() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LtePoe
+}
+
+func (s *Device) GetLteRoamingAllowed() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LteRoamingAllowed
+}
+
+func (s *Device) GetLteSimPin() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LteSimPin
+}
+
+func (s *Device) GetLteSoftLimit() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LteSoftLimit
+}
+
+func (s *Device) GetLteUsername() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LteUsername
+}
+
+func (s *Device) GetMapId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.MapId
+}
+
+func (s *Device) GetMeshStaVapEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MeshStaVapEnabled
+}
+
+func (s *Device) GetMgmtNetworkId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.MgmtNetworkId
+}
+
+func (s *Device) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *Device) GetOutdoorModeOverride() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OutdoorModeOverride
+}
+
+func (s *Device) GetOutletEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.OutletEnabled
+}
+
+func (s *Device) GetOutletOverrides() []DeviceOutletOverrides {
+	if s == nil || s.OutletOverrides == nil {
+		return nil
+	}
+
+	return *s.OutletOverrides
+}
+
+func (s *Device) GetOutletPowerCycleEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.OutletPowerCycleEnabled
+}
+
+func (s *Device) GetPeerToPeerMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PeerToPeerMode
+}
+
+func (s *Device) GetPoeMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PoeMode
+}
+
+func (s *Device) GetPortOverrides() []DevicePortOverrides {
+	if s == nil || s.PortOverrides == nil {
+		return nil
+	}
+
+	return *s.PortOverrides
+}
+
+func (s *Device) GetPowerSourceCtrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PowerSourceCtrl
+}
+
+func (s *Device) GetPowerSourceCtrlBudget() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PowerSourceCtrlBudget
+}
+
+func (s *Device) GetPowerSourceCtrlEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PowerSourceCtrlEnabled
+}
+
+func (s *Device) GetPtpApMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PtpApMac
+}
+
+func (s *Device) GetRadioTable() []DeviceRadioTable {
+	if s == nil || s.RadioTable == nil {
+		return nil
+	}
+
+	return *s.RadioTable
+}
+
+func (s *Device) GetRadiusprofileId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.RadiusprofileId
+}
+
+func (s *Device) GetResetbtnEnabled() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ResetbtnEnabled
+}
+
+func (s *Device) GetRpsOverride() *DeviceRpsOverride {
+	if s == nil || s.RpsOverride == nil {
+		return nil
+	}
+
+	return s.RpsOverride
+}
+
+func (s *Device) GetSnmpContact() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SnmpContact
+}
+
+func (s *Device) GetSnmpLocation() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SnmpLocation
+}
+
+func (s *Device) GetStationMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.StationMode
+}
+
+func (s *Device) GetStpPriority() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StpPriority
+}
+
+func (s *Device) GetStpVersion() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.StpVersion
+}
+
+func (s *Device) GetSwitchVlanEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.SwitchVlanEnabled
+}
+
+func (s *Device) GetUbbPairName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UbbPairName
+}
+
+func (s *Device) GetVolume() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Volume
+}
+
+func (s *Device) GetX() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.X
+}
+
+func (s *Device) GetXBaresipPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XBaresipPassword
+}
+
+func (s *Device) GetY() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Y
+}
+
 type DeviceConfigNetwork struct {
 	BondingEnabled *bool   `json:"bonding_enabled,omitempty"`
 	Dns1           *string `json:"dns1,omitempty"`
@@ -107,10 +715,98 @@ type DeviceConfigNetwork struct {
 	Type           *string `json:"type,omitempty"`
 }
 
+func (s *DeviceConfigNetwork) GetBondingEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.BondingEnabled
+}
+
+func (s *DeviceConfigNetwork) GetDns1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dns1
+}
+
+func (s *DeviceConfigNetwork) GetDns2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dns2
+}
+
+func (s *DeviceConfigNetwork) GetDnssuffix() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dnssuffix
+}
+
+func (s *DeviceConfigNetwork) GetGateway() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Gateway
+}
+
+func (s *DeviceConfigNetwork) GetIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ip
+}
+
+func (s *DeviceConfigNetwork) GetNetmask() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Netmask
+}
+
+func (s *DeviceConfigNetwork) GetType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Type
+}
+
 type DeviceEtherLighting struct {
 	Behavior   *string `json:"behavior,omitempty"`
 	Brightness *int64  `json:"brightness,omitempty"`
 	Mode       *string `json:"mode,omitempty"`
+}
+
+func (s *DeviceEtherLighting) GetBehavior() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Behavior
+}
+
+func (s *DeviceEtherLighting) GetBrightness() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Brightness
+}
+
+func (s *DeviceEtherLighting) GetMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Mode
 }
 
 type DeviceEthernetOverrides struct {
@@ -118,11 +814,59 @@ type DeviceEthernetOverrides struct {
 	Networkgroup *string `json:"networkgroup,omitempty"`
 }
 
+func (s *DeviceEthernetOverrides) GetIfname() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ifname
+}
+
+func (s *DeviceEthernetOverrides) GetNetworkgroup() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Networkgroup
+}
+
 type DeviceOutletOverrides struct {
 	CycleEnabled *bool   `json:"cycle_enabled,omitempty"`
 	Index        *int64  `json:"index,omitempty"`
 	Name         *string `json:"name,omitempty"`
 	RelayState   *bool   `json:"relay_state,omitempty"`
+}
+
+func (s *DeviceOutletOverrides) GetCycleEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.CycleEnabled
+}
+
+func (s *DeviceOutletOverrides) GetIndex() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Index
+}
+
+func (s *DeviceOutletOverrides) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *DeviceOutletOverrides) GetRelayState() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.RelayState
 }
 
 type DevicePortOverrides struct {
@@ -172,14 +916,398 @@ type DevicePortOverrides struct {
 	VoiceNetworkconfId            *string                        `json:"voice_networkconf_id,omitempty"`
 }
 
+func (s *DevicePortOverrides) GetAggregateNumPorts() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.AggregateNumPorts
+}
+
+func (s *DevicePortOverrides) GetAutoneg() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Autoneg
+}
+
+func (s *DevicePortOverrides) GetDot1XCtrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dot1XCtrl
+}
+
+func (s *DevicePortOverrides) GetDot1XIdleTimeout() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Dot1XIdleTimeout
+}
+
+func (s *DevicePortOverrides) GetEgressRateLimitKbps() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.EgressRateLimitKbps
+}
+
+func (s *DevicePortOverrides) GetEgressRateLimitKbpsEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.EgressRateLimitKbpsEnabled
+}
+
+func (s *DevicePortOverrides) GetExcludedNetworkconfIds() []string {
+	if s == nil || s.ExcludedNetworkconfIds == nil {
+		return nil
+	}
+
+	return *s.ExcludedNetworkconfIds
+}
+
+func (s *DevicePortOverrides) GetFecMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.FecMode
+}
+
+func (s *DevicePortOverrides) GetForward() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Forward
+}
+
+func (s *DevicePortOverrides) GetFullDuplex() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.FullDuplex
+}
+
+func (s *DevicePortOverrides) GetIsolation() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Isolation
+}
+
+func (s *DevicePortOverrides) GetLldpmedEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LldpmedEnabled
+}
+
+func (s *DevicePortOverrides) GetLldpmedNotifyEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LldpmedNotifyEnabled
+}
+
+func (s *DevicePortOverrides) GetMirrorPortIdx() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MirrorPortIdx
+}
+
+func (s *DevicePortOverrides) GetMulticastRouterNetworkconfIds() []string {
+	if s == nil || s.MulticastRouterNetworkconfIds == nil {
+		return nil
+	}
+
+	return *s.MulticastRouterNetworkconfIds
+}
+
+func (s *DevicePortOverrides) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *DevicePortOverrides) GetNativeNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NativeNetworkconfId
+}
+
+func (s *DevicePortOverrides) GetOpMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpMode
+}
+
+func (s *DevicePortOverrides) GetPoeMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PoeMode
+}
+
+func (s *DevicePortOverrides) GetPortIdx() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PortIdx
+}
+
+func (s *DevicePortOverrides) GetPortKeepaliveEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PortKeepaliveEnabled
+}
+
+func (s *DevicePortOverrides) GetPortSecurityEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PortSecurityEnabled
+}
+
+func (s *DevicePortOverrides) GetPortSecurityMacAddress() []string {
+	if s == nil || s.PortSecurityMacAddress == nil {
+		return nil
+	}
+
+	return *s.PortSecurityMacAddress
+}
+
+func (s *DevicePortOverrides) GetPortconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PortconfId
+}
+
+func (s *DevicePortOverrides) GetPriorityQueue1Level() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PriorityQueue1Level
+}
+
+func (s *DevicePortOverrides) GetPriorityQueue2Level() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PriorityQueue2Level
+}
+
+func (s *DevicePortOverrides) GetPriorityQueue3Level() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PriorityQueue3Level
+}
+
+func (s *DevicePortOverrides) GetPriorityQueue4Level() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PriorityQueue4Level
+}
+
+func (s *DevicePortOverrides) GetQosProfile() *DevicePortOverridesQosProfile {
+	if s == nil || s.QosProfile == nil {
+		return nil
+	}
+
+	return s.QosProfile
+}
+
+func (s *DevicePortOverrides) GetSettingPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SettingPreference
+}
+
+func (s *DevicePortOverrides) GetSpeed() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Speed
+}
+
+func (s *DevicePortOverrides) GetStormctrlBcastEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StormctrlBcastEnabled
+}
+
+func (s *DevicePortOverrides) GetStormctrlBcastLevel() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlBcastLevel
+}
+
+func (s *DevicePortOverrides) GetStormctrlBcastRate() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlBcastRate
+}
+
+func (s *DevicePortOverrides) GetStormctrlMcastEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StormctrlMcastEnabled
+}
+
+func (s *DevicePortOverrides) GetStormctrlMcastLevel() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlMcastLevel
+}
+
+func (s *DevicePortOverrides) GetStormctrlMcastRate() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlMcastRate
+}
+
+func (s *DevicePortOverrides) GetStormctrlType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.StormctrlType
+}
+
+func (s *DevicePortOverrides) GetStormctrlUcastEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StormctrlUcastEnabled
+}
+
+func (s *DevicePortOverrides) GetStormctrlUcastLevel() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlUcastLevel
+}
+
+func (s *DevicePortOverrides) GetStormctrlUcastRate() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlUcastRate
+}
+
+func (s *DevicePortOverrides) GetStpPortMode() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StpPortMode
+}
+
+func (s *DevicePortOverrides) GetTaggedVlanMgmt() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.TaggedVlanMgmt
+}
+
+func (s *DevicePortOverrides) GetVoiceNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VoiceNetworkconfId
+}
+
 type DevicePortOverridesQosProfile struct {
 	QosPolicies    *[]DevicePortOverridesQosProfileQosPolicies `json:"qos_policies,omitempty"`
 	QosProfileMode *string                                     `json:"qos_profile_mode,omitempty"`
 }
 
+func (s *DevicePortOverridesQosProfile) GetQosPolicies() []DevicePortOverridesQosProfileQosPolicies {
+	if s == nil || s.QosPolicies == nil {
+		return nil
+	}
+
+	return *s.QosPolicies
+}
+
+func (s *DevicePortOverridesQosProfile) GetQosProfileMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.QosProfileMode
+}
+
 type DevicePortOverridesQosProfileQosPolicies struct {
 	QosMarking  *DevicePortOverridesQosProfileQosPoliciesQosMarking  `json:"qos_marking,omitempty"`
 	QosMatching *DevicePortOverridesQosProfileQosPoliciesQosMatching `json:"qos_matching,omitempty"`
+}
+
+func (s *DevicePortOverridesQosProfileQosPolicies) GetQosMarking() *DevicePortOverridesQosProfileQosPoliciesQosMarking {
+	if s == nil || s.QosMarking == nil {
+		return nil
+	}
+
+	return s.QosMarking
+}
+
+func (s *DevicePortOverridesQosProfileQosPolicies) GetQosMatching() *DevicePortOverridesQosProfileQosPoliciesQosMatching {
+	if s == nil || s.QosMatching == nil {
+		return nil
+	}
+
+	return s.QosMatching
 }
 
 type DevicePortOverridesQosProfileQosPoliciesQosMarking struct {
@@ -189,6 +1317,38 @@ type DevicePortOverridesQosProfileQosPoliciesQosMarking struct {
 	Queue            *int64   `json:"queue,omitempty"`
 }
 
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMarking) GetCosCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.CosCode
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMarking) GetDscpCode() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DscpCode
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMarking) GetIpPrecedenceCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpPrecedenceCode
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMarking) GetQueue() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Queue
+}
+
 type DevicePortOverridesQosProfileQosPoliciesQosMatching struct {
 	CosCode          *int64   `json:"cos_code,omitempty"`
 	DscpCode         *int64   `json:"dscp_code,omitempty"`
@@ -196,6 +1356,54 @@ type DevicePortOverridesQosProfileQosPoliciesQosMatching struct {
 	IpPrecedenceCode *int64   `json:"ip_precedence_code,omitempty"`
 	Protocol         *string  `json:"protocol,omitempty"`
 	SrcPort          *float64 `json:"src_port,omitempty"`
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMatching) GetCosCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.CosCode
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMatching) GetDscpCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DscpCode
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMatching) GetDstPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DstPort
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMatching) GetIpPrecedenceCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpPrecedenceCode
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMatching) GetProtocol() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Protocol
+}
+
+func (s *DevicePortOverridesQosProfileQosPoliciesQosMatching) GetSrcPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.SrcPort
 }
 
 type DeviceRadioTable struct {
@@ -220,9 +1428,177 @@ type DeviceRadioTable struct {
 	VwireEnabled               *bool                               `json:"vwire_enabled,omitempty"`
 }
 
+func (s *DeviceRadioTable) GetAntennaGain() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.AntennaGain
+}
+
+func (s *DeviceRadioTable) GetAntennaId() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.AntennaId
+}
+
+func (s *DeviceRadioTable) GetBackupChannel() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.BackupChannel
+}
+
+func (s *DeviceRadioTable) GetChannel() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Channel
+}
+
+func (s *DeviceRadioTable) GetChannelOptimizationEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ChannelOptimizationEnabled
+}
+
+func (s *DeviceRadioTable) GetHardNoiseFloorEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.HardNoiseFloorEnabled
+}
+
+func (s *DeviceRadioTable) GetHt() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Ht
+}
+
+func (s *DeviceRadioTable) GetLoadbalanceEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LoadbalanceEnabled
+}
+
+func (s *DeviceRadioTable) GetMaxsta() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Maxsta
+}
+
+func (s *DeviceRadioTable) GetMinRssi() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MinRssi
+}
+
+func (s *DeviceRadioTable) GetMinRssiEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MinRssiEnabled
+}
+
+func (s *DeviceRadioTable) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *DeviceRadioTable) GetRadio() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Radio
+}
+
+func (s *DeviceRadioTable) GetRadioIdentifiers() []DeviceRadioTableRadioIdentifiers {
+	if s == nil || s.RadioIdentifiers == nil {
+		return nil
+	}
+
+	return *s.RadioIdentifiers
+}
+
+func (s *DeviceRadioTable) GetSensLevel() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.SensLevel
+}
+
+func (s *DeviceRadioTable) GetSensLevelEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.SensLevelEnabled
+}
+
+func (s *DeviceRadioTable) GetTxPower() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.TxPower
+}
+
+func (s *DeviceRadioTable) GetTxPowerMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.TxPowerMode
+}
+
+func (s *DeviceRadioTable) GetVwireEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.VwireEnabled
+}
+
 type DeviceRadioTableRadioIdentifiers struct {
 	DeviceId  *string `json:"device_id,omitempty"`
 	RadioName *string `json:"radio_name,omitempty"`
+}
+
+func (s *DeviceRadioTableRadioIdentifiers) GetDeviceId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DeviceId
+}
+
+func (s *DeviceRadioTableRadioIdentifiers) GetRadioName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.RadioName
 }
 
 type DeviceRpsOverride struct {
@@ -230,8 +1606,48 @@ type DeviceRpsOverride struct {
 	RpsPortTable        *[]DeviceRpsOverrideRpsPortTable `json:"rps_port_table,omitempty"`
 }
 
+func (s *DeviceRpsOverride) GetPowerManagementMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PowerManagementMode
+}
+
+func (s *DeviceRpsOverride) GetRpsPortTable() []DeviceRpsOverrideRpsPortTable {
+	if s == nil || s.RpsPortTable == nil {
+		return nil
+	}
+
+	return *s.RpsPortTable
+}
+
 type DeviceRpsOverrideRpsPortTable struct {
 	Name     *string `json:"name,omitempty"`
 	PortIdx  *int64  `json:"port_idx,omitempty"`
 	PortMode *string `json:"port_mode,omitempty"`
+}
+
+func (s *DeviceRpsOverrideRpsPortTable) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *DeviceRpsOverrideRpsPortTable) GetPortIdx() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PortIdx
+}
+
+func (s *DeviceRpsOverrideRpsPortTable) GetPortMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PortMode
 }

--- a/networkserver/dhcp_option.generated.go
+++ b/networkserver/dhcp_option.generated.go
@@ -24,3 +24,43 @@ type DhcpOption struct {
 	Type   *string `json:"type,omitempty"`
 	Width  *int64  `json:"width,omitempty"`
 }
+
+func (s *DhcpOption) GetCode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Code
+}
+
+func (s *DhcpOption) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *DhcpOption) GetSigned() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Signed
+}
+
+func (s *DhcpOption) GetType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Type
+}
+
+func (s *DhcpOption) GetWidth() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Width
+}

--- a/networkserver/dpi_app.generated.go
+++ b/networkserver/dpi_app.generated.go
@@ -27,3 +27,67 @@ type DpiApp struct {
 	QosRateMaxDown *float64 `json:"qos_rate_max_down,omitempty"`
 	QosRateMaxUp   *float64 `json:"qos_rate_max_up,omitempty"`
 }
+
+func (s *DpiApp) GetApps() []int64 {
+	if s == nil || s.Apps == nil {
+		return nil
+	}
+
+	return *s.Apps
+}
+
+func (s *DpiApp) GetBlocked() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Blocked
+}
+
+func (s *DpiApp) GetCats() []int64 {
+	if s == nil || s.Cats == nil {
+		return nil
+	}
+
+	return *s.Cats
+}
+
+func (s *DpiApp) GetEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Enabled
+}
+
+func (s *DpiApp) GetLog() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Log
+}
+
+func (s *DpiApp) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *DpiApp) GetQosRateMaxDown() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.QosRateMaxDown
+}
+
+func (s *DpiApp) GetQosRateMaxUp() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.QosRateMaxUp
+}

--- a/networkserver/dpi_group.generated.go
+++ b/networkserver/dpi_group.generated.go
@@ -22,3 +22,27 @@ type DpiGroup struct {
 	Enabled   *bool     `json:"enabled,omitempty"`
 	Name      *string   `json:"name,omitempty"`
 }
+
+func (s *DpiGroup) GetDpiappIds() []string {
+	if s == nil || s.DpiappIds == nil {
+		return nil
+	}
+
+	return *s.DpiappIds
+}
+
+func (s *DpiGroup) GetEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Enabled
+}
+
+func (s *DpiGroup) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}

--- a/networkserver/dynamic_dns.generated.go
+++ b/networkserver/dynamic_dns.generated.go
@@ -27,3 +27,67 @@ type DynamicDNS struct {
 	Service       *string   `json:"service,omitempty"`
 	XPassword     *string   `json:"x_password,omitempty"`
 }
+
+func (s *DynamicDNS) GetCustomService() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.CustomService
+}
+
+func (s *DynamicDNS) GetHostName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HostName
+}
+
+func (s *DynamicDNS) GetInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Interface
+}
+
+func (s *DynamicDNS) GetLogin() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Login
+}
+
+func (s *DynamicDNS) GetOptions() []string {
+	if s == nil || s.Options == nil {
+		return nil
+	}
+
+	return *s.Options
+}
+
+func (s *DynamicDNS) GetServer() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Server
+}
+
+func (s *DynamicDNS) GetService() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Service
+}
+
+func (s *DynamicDNS) GetXPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XPassword
+}

--- a/networkserver/firewall_group.generated.go
+++ b/networkserver/firewall_group.generated.go
@@ -22,3 +22,27 @@ type FirewallGroup struct {
 	GroupType    *string   `json:"group_type,omitempty"`
 	Name         *string   `json:"name,omitempty"`
 }
+
+func (s *FirewallGroup) GetGroupMembers() []string {
+	if s == nil || s.GroupMembers == nil {
+		return nil
+	}
+
+	return *s.GroupMembers
+}
+
+func (s *FirewallGroup) GetGroupType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.GroupType
+}
+
+func (s *FirewallGroup) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}

--- a/networkserver/firewall_rule.generated.go
+++ b/networkserver/firewall_rule.generated.go
@@ -59,3 +59,323 @@ type FirewallRule struct {
 	Weekdays              *string   `json:"weekdays,omitempty"`
 	WeekdaysNegate        *bool     `json:"weekdays_negate,omitempty"`
 }
+
+func (s *FirewallRule) GetAction() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Action
+}
+
+func (s *FirewallRule) GetContiguous() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Contiguous
+}
+
+func (s *FirewallRule) GetDstAddress() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DstAddress
+}
+
+func (s *FirewallRule) GetDstAddressIpv6() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DstAddressIpv6
+}
+
+func (s *FirewallRule) GetDstFirewallgroupIds() []string {
+	if s == nil || s.DstFirewallgroupIds == nil {
+		return nil
+	}
+
+	return *s.DstFirewallgroupIds
+}
+
+func (s *FirewallRule) GetDstNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DstNetworkconfId
+}
+
+func (s *FirewallRule) GetDstNetworkconfType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DstNetworkconfType
+}
+
+func (s *FirewallRule) GetDstPort() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DstPort
+}
+
+func (s *FirewallRule) GetEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Enabled
+}
+
+func (s *FirewallRule) GetIcmpTypename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IcmpTypename
+}
+
+func (s *FirewallRule) GetIcmpv6Typename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Icmpv6Typename
+}
+
+func (s *FirewallRule) GetIpsec() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipsec
+}
+
+func (s *FirewallRule) GetLogging() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Logging
+}
+
+func (s *FirewallRule) GetMonthdays() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Monthdays
+}
+
+func (s *FirewallRule) GetMonthdaysNegate() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MonthdaysNegate
+}
+
+func (s *FirewallRule) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *FirewallRule) GetProtocol() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Protocol
+}
+
+func (s *FirewallRule) GetProtocolMatchExcepted() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ProtocolMatchExcepted
+}
+
+func (s *FirewallRule) GetProtocolV6() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ProtocolV6
+}
+
+func (s *FirewallRule) GetRuleIndex() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.RuleIndex
+}
+
+func (s *FirewallRule) GetRuleset() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ruleset
+}
+
+func (s *FirewallRule) GetSettingPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SettingPreference
+}
+
+func (s *FirewallRule) GetSrcAddress() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SrcAddress
+}
+
+func (s *FirewallRule) GetSrcAddressIpv6() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SrcAddressIpv6
+}
+
+func (s *FirewallRule) GetSrcFirewallgroupIds() []string {
+	if s == nil || s.SrcFirewallgroupIds == nil {
+		return nil
+	}
+
+	return *s.SrcFirewallgroupIds
+}
+
+func (s *FirewallRule) GetSrcMacAddress() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SrcMacAddress
+}
+
+func (s *FirewallRule) GetSrcNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SrcNetworkconfId
+}
+
+func (s *FirewallRule) GetSrcNetworkconfType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SrcNetworkconfType
+}
+
+func (s *FirewallRule) GetSrcPort() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SrcPort
+}
+
+func (s *FirewallRule) GetStartdate() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Startdate
+}
+
+func (s *FirewallRule) GetStarttime() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Starttime
+}
+
+func (s *FirewallRule) GetStateEstablished() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StateEstablished
+}
+
+func (s *FirewallRule) GetStateInvalid() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StateInvalid
+}
+
+func (s *FirewallRule) GetStateNew() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StateNew
+}
+
+func (s *FirewallRule) GetStateRelated() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StateRelated
+}
+
+func (s *FirewallRule) GetStopdate() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Stopdate
+}
+
+func (s *FirewallRule) GetStoptime() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Stoptime
+}
+
+func (s *FirewallRule) GetUtc() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Utc
+}
+
+func (s *FirewallRule) GetWeekdays() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Weekdays
+}
+
+func (s *FirewallRule) GetWeekdaysNegate() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.WeekdaysNegate
+}

--- a/networkserver/hotspot_2_conf.generated.go
+++ b/networkserver/hotspot_2_conf.generated.go
@@ -70,10 +70,434 @@ type Hotspot2Conf struct {
 	VenueType               *float64                             `json:"venue_type,omitempty"`
 }
 
+func (s *Hotspot2Conf) GetAnqpDomainId() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.AnqpDomainId
+}
+
+func (s *Hotspot2Conf) GetCapab() []Hotspot2ConfCapab {
+	if s == nil || s.Capab == nil {
+		return nil
+	}
+
+	return *s.Capab
+}
+
+func (s *Hotspot2Conf) GetCellularNetworkList() []Hotspot2ConfCellularNetworkList {
+	if s == nil || s.CellularNetworkList == nil {
+		return nil
+	}
+
+	return *s.CellularNetworkList
+}
+
+func (s *Hotspot2Conf) GetDeauthReqTimeout() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DeauthReqTimeout
+}
+
+func (s *Hotspot2Conf) GetDisableDgaf() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DisableDgaf
+}
+
+func (s *Hotspot2Conf) GetDomainNameList() []string {
+	if s == nil || s.DomainNameList == nil {
+		return nil
+	}
+
+	return *s.DomainNameList
+}
+
+func (s *Hotspot2Conf) GetFriendlyName() []Hotspot2ConfFriendlyName {
+	if s == nil || s.FriendlyName == nil {
+		return nil
+	}
+
+	return *s.FriendlyName
+}
+
+func (s *Hotspot2Conf) GetGasAdvanced() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.GasAdvanced
+}
+
+func (s *Hotspot2Conf) GetGasComebackDelay() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.GasComebackDelay
+}
+
+func (s *Hotspot2Conf) GetGasFragLimit() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.GasFragLimit
+}
+
+func (s *Hotspot2Conf) GetHessid() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Hessid
+}
+
+func (s *Hotspot2Conf) GetHessidUsed() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.HessidUsed
+}
+
+func (s *Hotspot2Conf) GetIcons() []Hotspot2ConfIcons {
+	if s == nil || s.Icons == nil {
+		return nil
+	}
+
+	return *s.Icons
+}
+
+func (s *Hotspot2Conf) GetIpaddrTypeAvailV4() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpaddrTypeAvailV4
+}
+
+func (s *Hotspot2Conf) GetIpaddrTypeAvailV6() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpaddrTypeAvailV6
+}
+
+func (s *Hotspot2Conf) GetMetricsDownlinkLoad() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsDownlinkLoad
+}
+
+func (s *Hotspot2Conf) GetMetricsDownlinkLoadSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsDownlinkLoadSet
+}
+
+func (s *Hotspot2Conf) GetMetricsDownlinkSpeed() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsDownlinkSpeed
+}
+
+func (s *Hotspot2Conf) GetMetricsDownlinkSpeedSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsDownlinkSpeedSet
+}
+
+func (s *Hotspot2Conf) GetMetricsInfoAtCapacity() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsInfoAtCapacity
+}
+
+func (s *Hotspot2Conf) GetMetricsInfoLinkStatus() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.MetricsInfoLinkStatus
+}
+
+func (s *Hotspot2Conf) GetMetricsInfoSymmetric() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsInfoSymmetric
+}
+
+func (s *Hotspot2Conf) GetMetricsMeasurement() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsMeasurement
+}
+
+func (s *Hotspot2Conf) GetMetricsMeasurementSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsMeasurementSet
+}
+
+func (s *Hotspot2Conf) GetMetricsStatus() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsStatus
+}
+
+func (s *Hotspot2Conf) GetMetricsUplinkLoad() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsUplinkLoad
+}
+
+func (s *Hotspot2Conf) GetMetricsUplinkLoadSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsUplinkLoadSet
+}
+
+func (s *Hotspot2Conf) GetMetricsUplinkSpeed() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsUplinkSpeed
+}
+
+func (s *Hotspot2Conf) GetMetricsUplinkSpeedSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsUplinkSpeedSet
+}
+
+func (s *Hotspot2Conf) GetNaiRealmList() []Hotspot2ConfNaiRealmList {
+	if s == nil || s.NaiRealmList == nil {
+		return nil
+	}
+
+	return *s.NaiRealmList
+}
+
+func (s *Hotspot2Conf) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *Hotspot2Conf) GetNetworkAccessAsra() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NetworkAccessAsra
+}
+
+func (s *Hotspot2Conf) GetNetworkAccessEsr() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NetworkAccessEsr
+}
+
+func (s *Hotspot2Conf) GetNetworkAccessInternet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NetworkAccessInternet
+}
+
+func (s *Hotspot2Conf) GetNetworkAccessUesa() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NetworkAccessUesa
+}
+
+func (s *Hotspot2Conf) GetNetworkAuthType() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.NetworkAuthType
+}
+
+func (s *Hotspot2Conf) GetNetworkAuthUrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NetworkAuthUrl
+}
+
+func (s *Hotspot2Conf) GetNetworkType() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.NetworkType
+}
+
+func (s *Hotspot2Conf) GetOsu() []Hotspot2ConfOsu {
+	if s == nil || s.Osu == nil {
+		return nil
+	}
+
+	return *s.Osu
+}
+
+func (s *Hotspot2Conf) GetOsuSsid() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OsuSsid
+}
+
+func (s *Hotspot2Conf) GetQosMapDcsp() []Hotspot2ConfQosMapDcsp {
+	if s == nil || s.QosMapDcsp == nil {
+		return nil
+	}
+
+	return *s.QosMapDcsp
+}
+
+func (s *Hotspot2Conf) GetQosMapExceptions() []Hotspot2ConfQosMapExceptions {
+	if s == nil || s.QosMapExceptions == nil {
+		return nil
+	}
+
+	return *s.QosMapExceptions
+}
+
+func (s *Hotspot2Conf) GetQosMapStatus() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.QosMapStatus
+}
+
+func (s *Hotspot2Conf) GetRoamingConsortiumList() []Hotspot2ConfRoamingConsortiumList {
+	if s == nil || s.RoamingConsortiumList == nil {
+		return nil
+	}
+
+	return *s.RoamingConsortiumList
+}
+
+func (s *Hotspot2Conf) GetSaveTimestamp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SaveTimestamp
+}
+
+func (s *Hotspot2Conf) GetTCFilename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.TCFilename
+}
+
+func (s *Hotspot2Conf) GetTCTimestamp() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.TCTimestamp
+}
+
+func (s *Hotspot2Conf) GetVenueGroup() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.VenueGroup
+}
+
+func (s *Hotspot2Conf) GetVenueName() []Hotspot2ConfVenueName {
+	if s == nil || s.VenueName == nil {
+		return nil
+	}
+
+	return *s.VenueName
+}
+
+func (s *Hotspot2Conf) GetVenueType() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.VenueType
+}
+
 type Hotspot2ConfCapab struct {
 	Port     *float64 `json:"port,omitempty"`
 	Protocol *string  `json:"protocol,omitempty"`
 	Status   *string  `json:"status,omitempty"`
+}
+
+func (s *Hotspot2ConfCapab) GetPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Port
+}
+
+func (s *Hotspot2ConfCapab) GetProtocol() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Protocol
+}
+
+func (s *Hotspot2ConfCapab) GetStatus() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Status
 }
 
 type Hotspot2ConfCellularNetworkList struct {
@@ -82,9 +506,49 @@ type Hotspot2ConfCellularNetworkList struct {
 	Name *string `json:"name,omitempty"`
 }
 
+func (s *Hotspot2ConfCellularNetworkList) GetMcc() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Mcc
+}
+
+func (s *Hotspot2ConfCellularNetworkList) GetMnc() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Mnc
+}
+
+func (s *Hotspot2ConfCellularNetworkList) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
 type Hotspot2ConfFriendlyName struct {
 	Language *string `json:"language,omitempty"`
 	Text     *string `json:"text,omitempty"`
+}
+
+func (s *Hotspot2ConfFriendlyName) GetLanguage() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Language
+}
+
+func (s *Hotspot2ConfFriendlyName) GetText() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Text
 }
 
 type Hotspot2ConfIcons struct {
@@ -98,6 +562,70 @@ type Hotspot2ConfIcons struct {
 	Width    *int64  `json:"width,omitempty"`
 }
 
+func (s *Hotspot2ConfIcons) GetData() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Data
+}
+
+func (s *Hotspot2ConfIcons) GetFilename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Filename
+}
+
+func (s *Hotspot2ConfIcons) GetHeight() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Height
+}
+
+func (s *Hotspot2ConfIcons) GetLanguage() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Language
+}
+
+func (s *Hotspot2ConfIcons) GetMedia() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Media
+}
+
+func (s *Hotspot2ConfIcons) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *Hotspot2ConfIcons) GetSize() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Size
+}
+
+func (s *Hotspot2ConfIcons) GetWidth() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Width
+}
+
 type Hotspot2ConfNaiRealmList struct {
 	AuthIds   *string `json:"auth_ids,omitempty"`
 	AuthVals  *string `json:"auth_vals,omitempty"`
@@ -105,6 +633,54 @@ type Hotspot2ConfNaiRealmList struct {
 	Encoding  *int64  `json:"encoding,omitempty"`
 	Name      *string `json:"name,omitempty"`
 	Status    *bool   `json:"status,omitempty"`
+}
+
+func (s *Hotspot2ConfNaiRealmList) GetAuthIds() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.AuthIds
+}
+
+func (s *Hotspot2ConfNaiRealmList) GetAuthVals() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.AuthVals
+}
+
+func (s *Hotspot2ConfNaiRealmList) GetEapMethod() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.EapMethod
+}
+
+func (s *Hotspot2ConfNaiRealmList) GetEncoding() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Encoding
+}
+
+func (s *Hotspot2ConfNaiRealmList) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *Hotspot2ConfNaiRealmList) GetStatus() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Status
 }
 
 type Hotspot2ConfOsu struct {
@@ -119,9 +695,97 @@ type Hotspot2ConfOsu struct {
 	ServerUri        *string                        `json:"server_uri,omitempty"`
 }
 
+func (s *Hotspot2ConfOsu) GetDescription() []Hotspot2ConfOsuDescription {
+	if s == nil || s.Description == nil {
+		return nil
+	}
+
+	return *s.Description
+}
+
+func (s *Hotspot2ConfOsu) GetFriendlyName() []Hotspot2ConfOsuFriendlyName {
+	if s == nil || s.FriendlyName == nil {
+		return nil
+	}
+
+	return *s.FriendlyName
+}
+
+func (s *Hotspot2ConfOsu) GetIcon() []Hotspot2ConfOsuIcon {
+	if s == nil || s.Icon == nil {
+		return nil
+	}
+
+	return *s.Icon
+}
+
+func (s *Hotspot2ConfOsu) GetMethodOmaDm() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MethodOmaDm
+}
+
+func (s *Hotspot2ConfOsu) GetMethodSoapXmlSpp() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MethodSoapXmlSpp
+}
+
+func (s *Hotspot2ConfOsu) GetNai() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Nai
+}
+
+func (s *Hotspot2ConfOsu) GetNai2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Nai2
+}
+
+func (s *Hotspot2ConfOsu) GetOperatingClass() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OperatingClass
+}
+
+func (s *Hotspot2ConfOsu) GetServerUri() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ServerUri
+}
+
 type Hotspot2ConfOsuDescription struct {
 	Language *string `json:"language,omitempty"`
 	Text     *string `json:"text,omitempty"`
+}
+
+func (s *Hotspot2ConfOsuDescription) GetLanguage() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Language
+}
+
+func (s *Hotspot2ConfOsuDescription) GetText() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Text
 }
 
 type Hotspot2ConfOsuFriendlyName struct {
@@ -129,8 +793,32 @@ type Hotspot2ConfOsuFriendlyName struct {
 	Text     *string `json:"text,omitempty"`
 }
 
+func (s *Hotspot2ConfOsuFriendlyName) GetLanguage() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Language
+}
+
+func (s *Hotspot2ConfOsuFriendlyName) GetText() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Text
+}
+
 type Hotspot2ConfOsuIcon struct {
 	Name *string `json:"name,omitempty"`
+}
+
+func (s *Hotspot2ConfOsuIcon) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
 }
 
 type Hotspot2ConfQosMapDcsp struct {
@@ -138,9 +826,41 @@ type Hotspot2ConfQosMapDcsp struct {
 	Low  *int64 `json:"low,omitempty"`
 }
 
+func (s *Hotspot2ConfQosMapDcsp) GetHigh() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.High
+}
+
+func (s *Hotspot2ConfQosMapDcsp) GetLow() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Low
+}
+
 type Hotspot2ConfQosMapExceptions struct {
 	Dcsp *int64 `json:"dcsp,omitempty"`
 	Up   *int64 `json:"up,omitempty"`
+}
+
+func (s *Hotspot2ConfQosMapExceptions) GetDcsp() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Dcsp
+}
+
+func (s *Hotspot2ConfQosMapExceptions) GetUp() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Up
 }
 
 type Hotspot2ConfRoamingConsortiumList struct {
@@ -148,8 +868,48 @@ type Hotspot2ConfRoamingConsortiumList struct {
 	Oid  *string `json:"oid,omitempty"`
 }
 
+func (s *Hotspot2ConfRoamingConsortiumList) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *Hotspot2ConfRoamingConsortiumList) GetOid() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Oid
+}
+
 type Hotspot2ConfVenueName struct {
 	Language *string `json:"language,omitempty"`
 	Name     *string `json:"name,omitempty"`
 	Url      *string `json:"url,omitempty"`
+}
+
+func (s *Hotspot2ConfVenueName) GetLanguage() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Language
+}
+
+func (s *Hotspot2ConfVenueName) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *Hotspot2ConfVenueName) GetUrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Url
 }

--- a/networkserver/hotspot_op.generated.go
+++ b/networkserver/hotspot_op.generated.go
@@ -22,3 +22,27 @@ type HotspotOp struct {
 	Note      *string `json:"note,omitempty"`
 	XPassword *string `json:"x_password,omitempty"`
 }
+
+func (s *HotspotOp) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *HotspotOp) GetNote() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Note
+}
+
+func (s *HotspotOp) GetXPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XPassword
+}

--- a/networkserver/hotspot_package.generated.go
+++ b/networkserver/hotspot_package.generated.go
@@ -48,3 +48,235 @@ type HotspotPackage struct {
 	TrialDurationMinutes           *int64   `json:"trial_duration_minutes,omitempty"`
 	TrialReset                     *float64 `json:"trial_reset,omitempty"`
 }
+
+func (s *HotspotPackage) GetAmount() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Amount
+}
+
+func (s *HotspotPackage) GetChargedAs() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ChargedAs
+}
+
+func (s *HotspotPackage) GetCurrency() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Currency
+}
+
+func (s *HotspotPackage) GetCustomPaymentFieldsEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.CustomPaymentFieldsEnabled
+}
+
+func (s *HotspotPackage) GetHours() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Hours
+}
+
+func (s *HotspotPackage) GetIndex() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Index
+}
+
+func (s *HotspotPackage) GetLimitDown() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LimitDown
+}
+
+func (s *HotspotPackage) GetLimitOverwrite() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LimitOverwrite
+}
+
+func (s *HotspotPackage) GetLimitQuota() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LimitQuota
+}
+
+func (s *HotspotPackage) GetLimitUp() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LimitUp
+}
+
+func (s *HotspotPackage) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *HotspotPackage) GetPaymentFieldsAddressEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsAddressEnabled
+}
+
+func (s *HotspotPackage) GetPaymentFieldsAddressRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsAddressRequired
+}
+
+func (s *HotspotPackage) GetPaymentFieldsCityEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsCityEnabled
+}
+
+func (s *HotspotPackage) GetPaymentFieldsCityRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsCityRequired
+}
+
+func (s *HotspotPackage) GetPaymentFieldsCountryEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsCountryEnabled
+}
+
+func (s *HotspotPackage) GetPaymentFieldsCountryRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsCountryRequired
+}
+
+func (s *HotspotPackage) GetPaymentFieldsEmailEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsEmailEnabled
+}
+
+func (s *HotspotPackage) GetPaymentFieldsEmailRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsEmailRequired
+}
+
+func (s *HotspotPackage) GetPaymentFieldsFirstNameEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsFirstNameEnabled
+}
+
+func (s *HotspotPackage) GetPaymentFieldsFirstNameRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsFirstNameRequired
+}
+
+func (s *HotspotPackage) GetPaymentFieldsLastNameEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsLastNameEnabled
+}
+
+func (s *HotspotPackage) GetPaymentFieldsLastNameRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsLastNameRequired
+}
+
+func (s *HotspotPackage) GetPaymentFieldsStateEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsStateEnabled
+}
+
+func (s *HotspotPackage) GetPaymentFieldsStateRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsStateRequired
+}
+
+func (s *HotspotPackage) GetPaymentFieldsZipEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsZipEnabled
+}
+
+func (s *HotspotPackage) GetPaymentFieldsZipRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PaymentFieldsZipRequired
+}
+
+func (s *HotspotPackage) GetTrialDurationMinutes() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.TrialDurationMinutes
+}
+
+func (s *HotspotPackage) GetTrialReset() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.TrialReset
+}

--- a/networkserver/network_conf.generated.go
+++ b/networkserver/network_conf.generated.go
@@ -252,9 +252,1881 @@ type NetworkConf struct {
 	XWireguardPrivateKey                          *string                              `json:"x_wireguard_private_key,omitempty"`
 }
 
+func (s *NetworkConf) GetAutoScaleEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.AutoScaleEnabled
+}
+
+func (s *NetworkConf) GetDhcpRelayEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpRelayEnabled
+}
+
+func (s *NetworkConf) GetDhcpdBootEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpdBootEnabled
+}
+
+func (s *NetworkConf) GetDhcpdBootFilename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdBootFilename
+}
+
+func (s *NetworkConf) GetDhcpdBootServer() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdBootServer
+}
+
+func (s *NetworkConf) GetDhcpdConflictChecking() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpdConflictChecking
+}
+
+func (s *NetworkConf) GetDhcpdDns1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdDns1
+}
+
+func (s *NetworkConf) GetDhcpdDns2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdDns2
+}
+
+func (s *NetworkConf) GetDhcpdDns3() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdDns3
+}
+
+func (s *NetworkConf) GetDhcpdDns4() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdDns4
+}
+
+func (s *NetworkConf) GetDhcpdDnsEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpdDnsEnabled
+}
+
+func (s *NetworkConf) GetDhcpdEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpdEnabled
+}
+
+func (s *NetworkConf) GetDhcpdGateway() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdGateway
+}
+
+func (s *NetworkConf) GetDhcpdGatewayEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpdGatewayEnabled
+}
+
+func (s *NetworkConf) GetDhcpdIp1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdIp1
+}
+
+func (s *NetworkConf) GetDhcpdIp2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdIp2
+}
+
+func (s *NetworkConf) GetDhcpdIp3() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdIp3
+}
+
+func (s *NetworkConf) GetDhcpdLeasetime() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DhcpdLeasetime
+}
+
+func (s *NetworkConf) GetDhcpdMac1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdMac1
+}
+
+func (s *NetworkConf) GetDhcpdMac2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdMac2
+}
+
+func (s *NetworkConf) GetDhcpdMac3() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdMac3
+}
+
+func (s *NetworkConf) GetDhcpdNtp1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdNtp1
+}
+
+func (s *NetworkConf) GetDhcpdNtp2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdNtp2
+}
+
+func (s *NetworkConf) GetDhcpdNtpEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpdNtpEnabled
+}
+
+func (s *NetworkConf) GetDhcpdStart() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdStart
+}
+
+func (s *NetworkConf) GetDhcpdStop() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdStop
+}
+
+func (s *NetworkConf) GetDhcpdTftpServer() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdTftpServer
+}
+
+func (s *NetworkConf) GetDhcpdTimeOffset() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DhcpdTimeOffset
+}
+
+func (s *NetworkConf) GetDhcpdTimeOffsetEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpdTimeOffsetEnabled
+}
+
+func (s *NetworkConf) GetDhcpdUnifiController() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdUnifiController
+}
+
+func (s *NetworkConf) GetDhcpdWins1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdWins1
+}
+
+func (s *NetworkConf) GetDhcpdWins2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdWins2
+}
+
+func (s *NetworkConf) GetDhcpdWinsEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpdWinsEnabled
+}
+
+func (s *NetworkConf) GetDhcpdWpadUrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DhcpdWpadUrl
+}
+
+func (s *NetworkConf) GetDhcpdv6AllowSlaac() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Dhcpdv6AllowSlaac
+}
+
+func (s *NetworkConf) GetDhcpdv6Dns1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dhcpdv6Dns1
+}
+
+func (s *NetworkConf) GetDhcpdv6Dns2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dhcpdv6Dns2
+}
+
+func (s *NetworkConf) GetDhcpdv6Dns3() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dhcpdv6Dns3
+}
+
+func (s *NetworkConf) GetDhcpdv6Dns4() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dhcpdv6Dns4
+}
+
+func (s *NetworkConf) GetDhcpdv6DnsAuto() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Dhcpdv6DnsAuto
+}
+
+func (s *NetworkConf) GetDhcpdv6Enabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Dhcpdv6Enabled
+}
+
+func (s *NetworkConf) GetDhcpdv6Leasetime() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Dhcpdv6Leasetime
+}
+
+func (s *NetworkConf) GetDhcpdv6Start() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dhcpdv6Start
+}
+
+func (s *NetworkConf) GetDhcpdv6Stop() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dhcpdv6Stop
+}
+
+func (s *NetworkConf) GetDhcpguardEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DhcpguardEnabled
+}
+
+func (s *NetworkConf) GetDomainName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DomainName
+}
+
+func (s *NetworkConf) GetDpiEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DpiEnabled
+}
+
+func (s *NetworkConf) GetDpigroupId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DpigroupId
+}
+
+func (s *NetworkConf) GetEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Enabled
+}
+
+func (s *NetworkConf) GetExposedToSiteVpn() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ExposedToSiteVpn
+}
+
+func (s *NetworkConf) GetGatewayDevice() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.GatewayDevice
+}
+
+func (s *NetworkConf) GetGatewayType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.GatewayType
+}
+
+func (s *NetworkConf) GetIgmpFastleave() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IgmpFastleave
+}
+
+func (s *NetworkConf) GetIgmpForwardUnknownMulticast() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IgmpForwardUnknownMulticast
+}
+
+func (s *NetworkConf) GetIgmpGroupmembership() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IgmpGroupmembership
+}
+
+func (s *NetworkConf) GetIgmpMaxresponse() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IgmpMaxresponse
+}
+
+func (s *NetworkConf) GetIgmpMcrtrexpiretime() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IgmpMcrtrexpiretime
+}
+
+func (s *NetworkConf) GetIgmpProxyDownstreamNetworkconfIds() []string {
+	if s == nil || s.IgmpProxyDownstreamNetworkconfIds == nil {
+		return nil
+	}
+
+	return *s.IgmpProxyDownstreamNetworkconfIds
+}
+
+func (s *NetworkConf) GetIgmpProxyFor() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IgmpProxyFor
+}
+
+func (s *NetworkConf) GetIgmpProxyUpstream() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IgmpProxyUpstream
+}
+
+func (s *NetworkConf) GetIgmpQuerierSwitches() []NetworkConfIgmpQuerierSwitches {
+	if s == nil || s.IgmpQuerierSwitches == nil {
+		return nil
+	}
+
+	return *s.IgmpQuerierSwitches
+}
+
+func (s *NetworkConf) GetIgmpSnooping() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IgmpSnooping
+}
+
+func (s *NetworkConf) GetIgmpSupression() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IgmpSupression
+}
+
+func (s *NetworkConf) GetInterfaceMtu() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.InterfaceMtu
+}
+
+func (s *NetworkConf) GetInterfaceMtuEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.InterfaceMtuEnabled
+}
+
+func (s *NetworkConf) GetInternetAccessEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.InternetAccessEnabled
+}
+
+func (s *NetworkConf) GetIpSubnet() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpSubnet
+}
+
+func (s *NetworkConf) GetIpsecDhGroup() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpsecDhGroup
+}
+
+func (s *NetworkConf) GetIpsecDynamicRouting() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IpsecDynamicRouting
+}
+
+func (s *NetworkConf) GetIpsecEncryption() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecEncryption
+}
+
+func (s *NetworkConf) GetIpsecEspDhGroup() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpsecEspDhGroup
+}
+
+func (s *NetworkConf) GetIpsecEspEncryption() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecEspEncryption
+}
+
+func (s *NetworkConf) GetIpsecEspHash() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecEspHash
+}
+
+func (s *NetworkConf) GetIpsecEspLifetime() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecEspLifetime
+}
+
+func (s *NetworkConf) GetIpsecHash() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecHash
+}
+
+func (s *NetworkConf) GetIpsecIkeDhGroup() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpsecIkeDhGroup
+}
+
+func (s *NetworkConf) GetIpsecIkeEncryption() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecIkeEncryption
+}
+
+func (s *NetworkConf) GetIpsecIkeHash() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecIkeHash
+}
+
+func (s *NetworkConf) GetIpsecIkeLifetime() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecIkeLifetime
+}
+
+func (s *NetworkConf) GetIpsecInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecInterface
+}
+
+func (s *NetworkConf) GetIpsecKeyExchange() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecKeyExchange
+}
+
+func (s *NetworkConf) GetIpsecLocalIdentifier() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecLocalIdentifier
+}
+
+func (s *NetworkConf) GetIpsecLocalIdentifierEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IpsecLocalIdentifierEnabled
+}
+
+func (s *NetworkConf) GetIpsecLocalIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecLocalIp
+}
+
+func (s *NetworkConf) GetIpsecPeerIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecPeerIp
+}
+
+func (s *NetworkConf) GetIpsecPfs() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IpsecPfs
+}
+
+func (s *NetworkConf) GetIpsecProfile() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecProfile
+}
+
+func (s *NetworkConf) GetIpsecRemoteIdentifier() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecRemoteIdentifier
+}
+
+func (s *NetworkConf) GetIpsecRemoteIdentifierEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IpsecRemoteIdentifierEnabled
+}
+
+func (s *NetworkConf) GetIpsecSeparateIkev2Networks() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IpsecSeparateIkev2Networks
+}
+
+func (s *NetworkConf) GetIpsecTunnelIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpsecTunnelIp
+}
+
+func (s *NetworkConf) GetIpsecTunnelIpEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IpsecTunnelIpEnabled
+}
+
+func (s *NetworkConf) GetIpv6ClientAddressAssignment() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6ClientAddressAssignment
+}
+
+func (s *NetworkConf) GetIpv6InterfaceType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6InterfaceType
+}
+
+func (s *NetworkConf) GetIpv6PdAutoPrefixidEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Ipv6PdAutoPrefixidEnabled
+}
+
+func (s *NetworkConf) GetIpv6PdInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6PdInterface
+}
+
+func (s *NetworkConf) GetIpv6PdPrefixid() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6PdPrefixid
+}
+
+func (s *NetworkConf) GetIpv6PdStart() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6PdStart
+}
+
+func (s *NetworkConf) GetIpv6PdStop() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6PdStop
+}
+
+func (s *NetworkConf) GetIpv6RaEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Ipv6RaEnabled
+}
+
+func (s *NetworkConf) GetIpv6RaPreferredLifetime() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Ipv6RaPreferredLifetime
+}
+
+func (s *NetworkConf) GetIpv6RaPriority() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6RaPriority
+}
+
+func (s *NetworkConf) GetIpv6RaValidLifetime() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Ipv6RaValidLifetime
+}
+
+func (s *NetworkConf) GetIpv6SettingPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6SettingPreference
+}
+
+func (s *NetworkConf) GetIpv6SingleNetworkInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6SingleNetworkInterface
+}
+
+func (s *NetworkConf) GetIpv6Subnet() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6Subnet
+}
+
+func (s *NetworkConf) GetIpv6WanDelegationType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ipv6WanDelegationType
+}
+
+func (s *NetworkConf) GetIsNat() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IsNat
+}
+
+func (s *NetworkConf) GetL2TpAllowWeakCiphers() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.L2TpAllowWeakCiphers
+}
+
+func (s *NetworkConf) GetL2TpInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.L2TpInterface
+}
+
+func (s *NetworkConf) GetL2TpLocalWanIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.L2TpLocalWanIp
+}
+
+func (s *NetworkConf) GetLocalPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.LocalPort
+}
+
+func (s *NetworkConf) GetLteLanEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LteLanEnabled
+}
+
+func (s *NetworkConf) GetMacOverride() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.MacOverride
+}
+
+func (s *NetworkConf) GetMacOverrideEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MacOverrideEnabled
+}
+
+func (s *NetworkConf) GetMdnsEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MdnsEnabled
+}
+
+func (s *NetworkConf) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *NetworkConf) GetNatOutboundIpAddresses() []NetworkConfNatOutboundIpAddresses {
+	if s == nil || s.NatOutboundIpAddresses == nil {
+		return nil
+	}
+
+	return *s.NatOutboundIpAddresses
+}
+
+func (s *NetworkConf) GetNetworkIsolationEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NetworkIsolationEnabled
+}
+
+func (s *NetworkConf) GetNetworkgroup() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Networkgroup
+}
+
+func (s *NetworkConf) GetOpenvpnConfiguration() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnConfiguration
+}
+
+func (s *NetworkConf) GetOpenvpnConfigurationFilename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnConfigurationFilename
+}
+
+func (s *NetworkConf) GetOpenvpnEncryptionCipher() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnEncryptionCipher
+}
+
+func (s *NetworkConf) GetOpenvpnInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnInterface
+}
+
+func (s *NetworkConf) GetOpenvpnLocalAddress() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnLocalAddress
+}
+
+func (s *NetworkConf) GetOpenvpnLocalPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.OpenvpnLocalPort
+}
+
+func (s *NetworkConf) GetOpenvpnLocalWanIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnLocalWanIp
+}
+
+func (s *NetworkConf) GetOpenvpnMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnMode
+}
+
+func (s *NetworkConf) GetOpenvpnRemoteAddress() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnRemoteAddress
+}
+
+func (s *NetworkConf) GetOpenvpnRemoteHost() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnRemoteHost
+}
+
+func (s *NetworkConf) GetOpenvpnRemotePort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.OpenvpnRemotePort
+}
+
+func (s *NetworkConf) GetOpenvpnUsername() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpenvpnUsername
+}
+
+func (s *NetworkConf) GetPptpcRequireMppe() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PptpcRequireMppe
+}
+
+func (s *NetworkConf) GetPptpcRouteDistance() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PptpcRouteDistance
+}
+
+func (s *NetworkConf) GetPptpcServerIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PptpcServerIp
+}
+
+func (s *NetworkConf) GetPptpcUsername() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PptpcUsername
+}
+
+func (s *NetworkConf) GetPriority() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Priority
+}
+
+func (s *NetworkConf) GetPurpose() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Purpose
+}
+
+func (s *NetworkConf) GetRadiusprofileId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.RadiusprofileId
+}
+
+func (s *NetworkConf) GetRemoteSiteId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.RemoteSiteId
+}
+
+func (s *NetworkConf) GetRemoteSiteSubnets() []string {
+	if s == nil || s.RemoteSiteSubnets == nil {
+		return nil
+	}
+
+	return *s.RemoteSiteSubnets
+}
+
+func (s *NetworkConf) GetRemoteVpnDynamicSubnetsEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.RemoteVpnDynamicSubnetsEnabled
+}
+
+func (s *NetworkConf) GetRemoteVpnSubnets() []string {
+	if s == nil || s.RemoteVpnSubnets == nil {
+		return nil
+	}
+
+	return *s.RemoteVpnSubnets
+}
+
+func (s *NetworkConf) GetReportWanEvent() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ReportWanEvent
+}
+
+func (s *NetworkConf) GetRequireMschapv2() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.RequireMschapv2
+}
+
+func (s *NetworkConf) GetRouteDistance() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.RouteDistance
+}
+
+func (s *NetworkConf) GetSettingPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SettingPreference
+}
+
+func (s *NetworkConf) GetSingleNetworkLan() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SingleNetworkLan
+}
+
+func (s *NetworkConf) GetUidPolicyEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UidPolicyEnabled
+}
+
+func (s *NetworkConf) GetUidPolicyName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UidPolicyName
+}
+
+func (s *NetworkConf) GetUidPublicGatewayPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.UidPublicGatewayPort
+}
+
+func (s *NetworkConf) GetUidTrafficRulesAllowedIpsAndHostnames() []string {
+	if s == nil || s.UidTrafficRulesAllowedIpsAndHostnames == nil {
+		return nil
+	}
+
+	return *s.UidTrafficRulesAllowedIpsAndHostnames
+}
+
+func (s *NetworkConf) GetUidTrafficRulesEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UidTrafficRulesEnabled
+}
+
+func (s *NetworkConf) GetUidVpnCustomRouting() []string {
+	if s == nil || s.UidVpnCustomRouting == nil {
+		return nil
+	}
+
+	return *s.UidVpnCustomRouting
+}
+
+func (s *NetworkConf) GetUidVpnDefaultDnsSuffix() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UidVpnDefaultDnsSuffix
+}
+
+func (s *NetworkConf) GetUidVpnMasqueradeEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UidVpnMasqueradeEnabled
+}
+
+func (s *NetworkConf) GetUidVpnMaxConnectionTimeSeconds() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.UidVpnMaxConnectionTimeSeconds
+}
+
+func (s *NetworkConf) GetUidVpnSyncPublicIp() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UidVpnSyncPublicIp
+}
+
+func (s *NetworkConf) GetUidVpnType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UidVpnType
+}
+
+func (s *NetworkConf) GetUidWorkspaceUrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UidWorkspaceUrl
+}
+
+func (s *NetworkConf) GetUpnpLanEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UpnpLanEnabled
+}
+
+func (s *NetworkConf) GetUsergroupId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UsergroupId
+}
+
+func (s *NetworkConf) GetVlan() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Vlan
+}
+
+func (s *NetworkConf) GetVlanEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.VlanEnabled
+}
+
+func (s *NetworkConf) GetVpnClientConfigurationRemoteIpOverride() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VpnClientConfigurationRemoteIpOverride
+}
+
+func (s *NetworkConf) GetVpnClientConfigurationRemoteIpOverrideEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.VpnClientConfigurationRemoteIpOverrideEnabled
+}
+
+func (s *NetworkConf) GetVpnClientDefaultRoute() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.VpnClientDefaultRoute
+}
+
+func (s *NetworkConf) GetVpnClientPullDns() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.VpnClientPullDns
+}
+
+func (s *NetworkConf) GetVpnProtocol() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VpnProtocol
+}
+
+func (s *NetworkConf) GetVpnType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VpnType
+}
+
+func (s *NetworkConf) GetVrrpIpSubnetGw1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VrrpIpSubnetGw1
+}
+
+func (s *NetworkConf) GetVrrpIpSubnetGw2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VrrpIpSubnetGw2
+}
+
+func (s *NetworkConf) GetVrrpVrid() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.VrrpVrid
+}
+
+func (s *NetworkConf) GetWanDhcpCos() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WanDhcpCos
+}
+
+func (s *NetworkConf) GetWanDhcpOptions() []NetworkConfWanDhcpOptions {
+	if s == nil || s.WanDhcpOptions == nil {
+		return nil
+	}
+
+	return *s.WanDhcpOptions
+}
+
+func (s *NetworkConf) GetWanDhcpv6PdSize() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WanDhcpv6PdSize
+}
+
+func (s *NetworkConf) GetWanDns1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanDns1
+}
+
+func (s *NetworkConf) GetWanDns2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanDns2
+}
+
+func (s *NetworkConf) GetWanDns3() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanDns3
+}
+
+func (s *NetworkConf) GetWanDns4() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanDns4
+}
+
+func (s *NetworkConf) GetWanDnsPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanDnsPreference
+}
+
+func (s *NetworkConf) GetWanDsliteRemoteHost() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanDsliteRemoteHost
+}
+
+func (s *NetworkConf) GetWanEgressQos() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WanEgressQos
+}
+
+func (s *NetworkConf) GetWanGateway() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanGateway
+}
+
+func (s *NetworkConf) GetWanGatewayV6() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanGatewayV6
+}
+
+func (s *NetworkConf) GetWanIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanIp
+}
+
+func (s *NetworkConf) GetWanIpAliases() []string {
+	if s == nil || s.WanIpAliases == nil {
+		return nil
+	}
+
+	return *s.WanIpAliases
+}
+
+func (s *NetworkConf) GetWanIpv6() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanIpv6
+}
+
+func (s *NetworkConf) GetWanIpv6Dns1() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanIpv6Dns1
+}
+
+func (s *NetworkConf) GetWanIpv6Dns2() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanIpv6Dns2
+}
+
+func (s *NetworkConf) GetWanIpv6DnsPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanIpv6DnsPreference
+}
+
+func (s *NetworkConf) GetWanLoadBalanceType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanLoadBalanceType
+}
+
+func (s *NetworkConf) GetWanLoadBalanceWeight() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WanLoadBalanceWeight
+}
+
+func (s *NetworkConf) GetWanNetmask() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanNetmask
+}
+
+func (s *NetworkConf) GetWanNetworkgroup() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanNetworkgroup
+}
+
+func (s *NetworkConf) GetWanPppoePasswordEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.WanPppoePasswordEnabled
+}
+
+func (s *NetworkConf) GetWanPppoeUsernameEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.WanPppoeUsernameEnabled
+}
+
+func (s *NetworkConf) GetWanPrefixlen() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WanPrefixlen
+}
+
+func (s *NetworkConf) GetWanProviderCapabilities() *NetworkConfWanProviderCapabilities {
+	if s == nil || s.WanProviderCapabilities == nil {
+		return nil
+	}
+
+	return s.WanProviderCapabilities
+}
+
+func (s *NetworkConf) GetWanSmartqDownRate() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WanSmartqDownRate
+}
+
+func (s *NetworkConf) GetWanSmartqEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.WanSmartqEnabled
+}
+
+func (s *NetworkConf) GetWanSmartqUpRate() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WanSmartqUpRate
+}
+
+func (s *NetworkConf) GetWanType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanType
+}
+
+func (s *NetworkConf) GetWanTypeV6() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanTypeV6
+}
+
+func (s *NetworkConf) GetWanUsername() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanUsername
+}
+
+func (s *NetworkConf) GetWanVlan() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WanVlan
+}
+
+func (s *NetworkConf) GetWanVlanEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.WanVlanEnabled
+}
+
+func (s *NetworkConf) GetWireguardClientConfigurationFile() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardClientConfigurationFile
+}
+
+func (s *NetworkConf) GetWireguardClientConfigurationFilename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardClientConfigurationFilename
+}
+
+func (s *NetworkConf) GetWireguardClientMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardClientMode
+}
+
+func (s *NetworkConf) GetWireguardClientPeerIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardClientPeerIp
+}
+
+func (s *NetworkConf) GetWireguardClientPeerPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WireguardClientPeerPort
+}
+
+func (s *NetworkConf) GetWireguardClientPeerPublicKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardClientPeerPublicKey
+}
+
+func (s *NetworkConf) GetWireguardClientPresharedKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardClientPresharedKey
+}
+
+func (s *NetworkConf) GetWireguardClientPresharedKeyEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.WireguardClientPresharedKeyEnabled
+}
+
+func (s *NetworkConf) GetWireguardInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardInterface
+}
+
+func (s *NetworkConf) GetWireguardLocalWanIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardLocalWanIp
+}
+
+func (s *NetworkConf) GetWireguardPublicKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WireguardPublicKey
+}
+
+func (s *NetworkConf) GetXAuthKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XAuthKey
+}
+
+func (s *NetworkConf) GetXCaCrt() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XCaCrt
+}
+
+func (s *NetworkConf) GetXCaKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XCaKey
+}
+
+func (s *NetworkConf) GetXDhKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XDhKey
+}
+
+func (s *NetworkConf) GetXIpsecPreSharedKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XIpsecPreSharedKey
+}
+
+func (s *NetworkConf) GetXOpenvpnPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XOpenvpnPassword
+}
+
+func (s *NetworkConf) GetXOpenvpnSharedSecretKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XOpenvpnSharedSecretKey
+}
+
+func (s *NetworkConf) GetXPptpcPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XPptpcPassword
+}
+
+func (s *NetworkConf) GetXServerCrt() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XServerCrt
+}
+
+func (s *NetworkConf) GetXServerKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XServerKey
+}
+
+func (s *NetworkConf) GetXSharedClientCrt() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XSharedClientCrt
+}
+
+func (s *NetworkConf) GetXSharedClientKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XSharedClientKey
+}
+
+func (s *NetworkConf) GetXWanPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XWanPassword
+}
+
+func (s *NetworkConf) GetXWireguardPrivateKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XWireguardPrivateKey
+}
+
 type NetworkConfIgmpQuerierSwitches struct {
 	QuerierAddress *string `json:"querier_address,omitempty"`
 	SwitchMac      *string `json:"switch_mac,omitempty"`
+}
+
+func (s *NetworkConfIgmpQuerierSwitches) GetQuerierAddress() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.QuerierAddress
+}
+
+func (s *NetworkConfIgmpQuerierSwitches) GetSwitchMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SwitchMac
 }
 
 type NetworkConfNatOutboundIpAddresses struct {
@@ -264,12 +2136,76 @@ type NetworkConfNatOutboundIpAddresses struct {
 	WanNetworkGroup *string   `json:"wan_network_group,omitempty"`
 }
 
+func (s *NetworkConfNatOutboundIpAddresses) GetIpAddress() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.IpAddress
+}
+
+func (s *NetworkConfNatOutboundIpAddresses) GetIpAddressPool() []string {
+	if s == nil || s.IpAddressPool == nil {
+		return nil
+	}
+
+	return *s.IpAddressPool
+}
+
+func (s *NetworkConfNatOutboundIpAddresses) GetMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Mode
+}
+
+func (s *NetworkConfNatOutboundIpAddresses) GetWanNetworkGroup() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WanNetworkGroup
+}
+
 type NetworkConfWanDhcpOptions struct {
 	OptionNumber *float64 `json:"optionNumber,omitempty"`
 	Value        *string  `json:"value,omitempty"`
 }
 
+func (s *NetworkConfWanDhcpOptions) GetOptionNumber() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.OptionNumber
+}
+
+func (s *NetworkConfWanDhcpOptions) GetValue() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Value
+}
+
 type NetworkConfWanProviderCapabilities struct {
 	DownloadKilobitsPerSecond *int64 `json:"download_kilobits_per_second,omitempty"`
 	UploadKilobitsPerSecond   *int64 `json:"upload_kilobits_per_second,omitempty"`
+}
+
+func (s *NetworkConfWanProviderCapabilities) GetDownloadKilobitsPerSecond() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DownloadKilobitsPerSecond
+}
+
+func (s *NetworkConfWanProviderCapabilities) GetUploadKilobitsPerSecond() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.UploadKilobitsPerSecond
 }

--- a/networkserver/port_conf.generated.go
+++ b/networkserver/port_conf.generated.go
@@ -60,14 +60,366 @@ type PortConf struct {
 	VoiceNetworkconfId            *string             `json:"voice_networkconf_id,omitempty"`
 }
 
+func (s *PortConf) GetAutoneg() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Autoneg
+}
+
+func (s *PortConf) GetDot1XCtrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Dot1XCtrl
+}
+
+func (s *PortConf) GetDot1XIdleTimeout() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Dot1XIdleTimeout
+}
+
+func (s *PortConf) GetEgressRateLimitKbps() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.EgressRateLimitKbps
+}
+
+func (s *PortConf) GetEgressRateLimitKbpsEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.EgressRateLimitKbpsEnabled
+}
+
+func (s *PortConf) GetExcludedNetworkconfIds() []string {
+	if s == nil || s.ExcludedNetworkconfIds == nil {
+		return nil
+	}
+
+	return *s.ExcludedNetworkconfIds
+}
+
+func (s *PortConf) GetFecMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.FecMode
+}
+
+func (s *PortConf) GetForward() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Forward
+}
+
+func (s *PortConf) GetFullDuplex() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.FullDuplex
+}
+
+func (s *PortConf) GetIsolation() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Isolation
+}
+
+func (s *PortConf) GetLldpmedEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LldpmedEnabled
+}
+
+func (s *PortConf) GetLldpmedNotifyEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LldpmedNotifyEnabled
+}
+
+func (s *PortConf) GetMulticastRouterNetworkconfIds() []string {
+	if s == nil || s.MulticastRouterNetworkconfIds == nil {
+		return nil
+	}
+
+	return *s.MulticastRouterNetworkconfIds
+}
+
+func (s *PortConf) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *PortConf) GetNativeNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NativeNetworkconfId
+}
+
+func (s *PortConf) GetOpMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.OpMode
+}
+
+func (s *PortConf) GetPoeMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PoeMode
+}
+
+func (s *PortConf) GetPortKeepaliveEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PortKeepaliveEnabled
+}
+
+func (s *PortConf) GetPortSecurityEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PortSecurityEnabled
+}
+
+func (s *PortConf) GetPortSecurityMacAddress() []string {
+	if s == nil || s.PortSecurityMacAddress == nil {
+		return nil
+	}
+
+	return *s.PortSecurityMacAddress
+}
+
+func (s *PortConf) GetPriorityQueue1Level() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PriorityQueue1Level
+}
+
+func (s *PortConf) GetPriorityQueue2Level() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PriorityQueue2Level
+}
+
+func (s *PortConf) GetPriorityQueue3Level() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PriorityQueue3Level
+}
+
+func (s *PortConf) GetPriorityQueue4Level() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.PriorityQueue4Level
+}
+
+func (s *PortConf) GetQosProfile() *PortConfQosProfile {
+	if s == nil || s.QosProfile == nil {
+		return nil
+	}
+
+	return s.QosProfile
+}
+
+func (s *PortConf) GetSettingPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SettingPreference
+}
+
+func (s *PortConf) GetSpeed() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Speed
+}
+
+func (s *PortConf) GetStormctrlBcastEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StormctrlBcastEnabled
+}
+
+func (s *PortConf) GetStormctrlBcastLevel() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlBcastLevel
+}
+
+func (s *PortConf) GetStormctrlBcastRate() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlBcastRate
+}
+
+func (s *PortConf) GetStormctrlMcastEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StormctrlMcastEnabled
+}
+
+func (s *PortConf) GetStormctrlMcastLevel() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlMcastLevel
+}
+
+func (s *PortConf) GetStormctrlMcastRate() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlMcastRate
+}
+
+func (s *PortConf) GetStormctrlType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.StormctrlType
+}
+
+func (s *PortConf) GetStormctrlUcastEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StormctrlUcastEnabled
+}
+
+func (s *PortConf) GetStormctrlUcastLevel() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlUcastLevel
+}
+
+func (s *PortConf) GetStormctrlUcastRate() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StormctrlUcastRate
+}
+
+func (s *PortConf) GetStpPortMode() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.StpPortMode
+}
+
+func (s *PortConf) GetTaggedVlanMgmt() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.TaggedVlanMgmt
+}
+
+func (s *PortConf) GetVoiceNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VoiceNetworkconfId
+}
+
 type PortConfQosProfile struct {
 	QosPolicies    *[]PortConfQosProfileQosPolicies `json:"qos_policies,omitempty"`
 	QosProfileMode *string                          `json:"qos_profile_mode,omitempty"`
 }
 
+func (s *PortConfQosProfile) GetQosPolicies() []PortConfQosProfileQosPolicies {
+	if s == nil || s.QosPolicies == nil {
+		return nil
+	}
+
+	return *s.QosPolicies
+}
+
+func (s *PortConfQosProfile) GetQosProfileMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.QosProfileMode
+}
+
 type PortConfQosProfileQosPolicies struct {
 	QosMarking  *PortConfQosProfileQosPoliciesQosMarking  `json:"qos_marking,omitempty"`
 	QosMatching *PortConfQosProfileQosPoliciesQosMatching `json:"qos_matching,omitempty"`
+}
+
+func (s *PortConfQosProfileQosPolicies) GetQosMarking() *PortConfQosProfileQosPoliciesQosMarking {
+	if s == nil || s.QosMarking == nil {
+		return nil
+	}
+
+	return s.QosMarking
+}
+
+func (s *PortConfQosProfileQosPolicies) GetQosMatching() *PortConfQosProfileQosPoliciesQosMatching {
+	if s == nil || s.QosMatching == nil {
+		return nil
+	}
+
+	return s.QosMatching
 }
 
 type PortConfQosProfileQosPoliciesQosMarking struct {
@@ -77,6 +429,38 @@ type PortConfQosProfileQosPoliciesQosMarking struct {
 	Queue            *int64   `json:"queue,omitempty"`
 }
 
+func (s *PortConfQosProfileQosPoliciesQosMarking) GetCosCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.CosCode
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMarking) GetDscpCode() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DscpCode
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMarking) GetIpPrecedenceCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpPrecedenceCode
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMarking) GetQueue() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Queue
+}
+
 type PortConfQosProfileQosPoliciesQosMatching struct {
 	CosCode          *int64   `json:"cos_code,omitempty"`
 	DscpCode         *int64   `json:"dscp_code,omitempty"`
@@ -84,4 +468,52 @@ type PortConfQosProfileQosPoliciesQosMatching struct {
 	IpPrecedenceCode *int64   `json:"ip_precedence_code,omitempty"`
 	Protocol         *string  `json:"protocol,omitempty"`
 	SrcPort          *float64 `json:"src_port,omitempty"`
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMatching) GetCosCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.CosCode
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMatching) GetDscpCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DscpCode
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMatching) GetDstPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DstPort
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMatching) GetIpPrecedenceCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpPrecedenceCode
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMatching) GetProtocol() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Protocol
+}
+
+func (s *PortConfQosProfileQosPoliciesQosMatching) GetSrcPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.SrcPort
 }

--- a/networkserver/port_forward.generated.go
+++ b/networkserver/port_forward.generated.go
@@ -34,7 +34,135 @@ type PortForward struct {
 	SrcLimitingType    *string                      `json:"src_limiting_type,omitempty"`
 }
 
+func (s *PortForward) GetDestinationIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DestinationIp
+}
+
+func (s *PortForward) GetDestinationIps() []PortForwardDestinationIps {
+	if s == nil || s.DestinationIps == nil {
+		return nil
+	}
+
+	return *s.DestinationIps
+}
+
+func (s *PortForward) GetDstPort() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DstPort
+}
+
+func (s *PortForward) GetEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Enabled
+}
+
+func (s *PortForward) GetFwd() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Fwd
+}
+
+func (s *PortForward) GetFwdPort() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.FwdPort
+}
+
+func (s *PortForward) GetLog() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Log
+}
+
+func (s *PortForward) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *PortForward) GetPfwdInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PfwdInterface
+}
+
+func (s *PortForward) GetProto() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Proto
+}
+
+func (s *PortForward) GetSrc() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Src
+}
+
+func (s *PortForward) GetSrcFirewallGroupId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SrcFirewallGroupId
+}
+
+func (s *PortForward) GetSrcLimitingEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.SrcLimitingEnabled
+}
+
+func (s *PortForward) GetSrcLimitingType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SrcLimitingType
+}
+
 type PortForwardDestinationIps struct {
 	DestinationIp *string `json:"destination_ip,omitempty"`
 	Interface     *string `json:"interface,omitempty"`
+}
+
+func (s *PortForwardDestinationIps) GetDestinationIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DestinationIp
+}
+
+func (s *PortForwardDestinationIps) GetInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Interface
 }

--- a/networkserver/radius_profile.generated.go
+++ b/networkserver/radius_profile.generated.go
@@ -38,14 +38,206 @@ type RadiusProfile struct {
 	XClientPrivateKeyPassword *string                     `json:"x_client_private_key_password,omitempty"`
 }
 
+func (s *RadiusProfile) GetAccountingEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.AccountingEnabled
+}
+
+func (s *RadiusProfile) GetAcctServers() []RadiusProfileAcctServers {
+	if s == nil || s.AcctServers == nil {
+		return nil
+	}
+
+	return *s.AcctServers
+}
+
+func (s *RadiusProfile) GetAuthServers() []RadiusProfileAuthServers {
+	if s == nil || s.AuthServers == nil {
+		return nil
+	}
+
+	return *s.AuthServers
+}
+
+func (s *RadiusProfile) GetInterimUpdateEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.InterimUpdateEnabled
+}
+
+func (s *RadiusProfile) GetInterimUpdateInterval() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.InterimUpdateInterval
+}
+
+func (s *RadiusProfile) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *RadiusProfile) GetTlsEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.TlsEnabled
+}
+
+func (s *RadiusProfile) GetUseUsgAcctServer() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UseUsgAcctServer
+}
+
+func (s *RadiusProfile) GetUseUsgAuthServer() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UseUsgAuthServer
+}
+
+func (s *RadiusProfile) GetVlanEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.VlanEnabled
+}
+
+func (s *RadiusProfile) GetVlanWlanMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VlanWlanMode
+}
+
+func (s *RadiusProfile) GetXCaCrt() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XCaCrt
+}
+
+func (s *RadiusProfile) GetXCaCrtFilename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XCaCrtFilename
+}
+
+func (s *RadiusProfile) GetXClientCrt() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XClientCrt
+}
+
+func (s *RadiusProfile) GetXClientCrtFilename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XClientCrtFilename
+}
+
+func (s *RadiusProfile) GetXClientPrivateKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XClientPrivateKey
+}
+
+func (s *RadiusProfile) GetXClientPrivateKeyFilename() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XClientPrivateKeyFilename
+}
+
+func (s *RadiusProfile) GetXClientPrivateKeyPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XClientPrivateKeyPassword
+}
+
 type RadiusProfileAcctServers struct {
 	Ip      *string  `json:"ip,omitempty"`
 	Port    *float64 `json:"port,omitempty"`
 	XSecret *string  `json:"x_secret,omitempty"`
 }
 
+func (s *RadiusProfileAcctServers) GetIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ip
+}
+
+func (s *RadiusProfileAcctServers) GetPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Port
+}
+
+func (s *RadiusProfileAcctServers) GetXSecret() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XSecret
+}
+
 type RadiusProfileAuthServers struct {
 	Ip      *string  `json:"ip,omitempty"`
 	Port    *float64 `json:"port,omitempty"`
 	XSecret *string  `json:"x_secret,omitempty"`
+}
+
+func (s *RadiusProfileAuthServers) GetIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Ip
+}
+
+func (s *RadiusProfileAuthServers) GetPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Port
+}
+
+func (s *RadiusProfileAuthServers) GetXSecret() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XSecret
 }

--- a/networkserver/routing.generated.go
+++ b/networkserver/routing.generated.go
@@ -29,3 +29,83 @@ type Routing struct {
 	StaticRouteType      *string `json:"static-route_type,omitempty"`
 	Type                 *string `json:"type,omitempty"`
 }
+
+func (s *Routing) GetEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Enabled
+}
+
+func (s *Routing) GetGatewayDevice() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.GatewayDevice
+}
+
+func (s *Routing) GetGatewayType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.GatewayType
+}
+
+func (s *Routing) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *Routing) GetStaticRouteDistance() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StaticRouteDistance
+}
+
+func (s *Routing) GetStaticRouteInterface() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.StaticRouteInterface
+}
+
+func (s *Routing) GetStaticRouteNetwork() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.StaticRouteNetwork
+}
+
+func (s *Routing) GetStaticRouteNexthop() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.StaticRouteNexthop
+}
+
+func (s *Routing) GetStaticRouteType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.StaticRouteType
+}
+
+func (s *Routing) GetType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Type
+}

--- a/networkserver/schedule_task.generated.go
+++ b/networkserver/schedule_task.generated.go
@@ -25,6 +25,54 @@ type ScheduleTask struct {
 	UpgradeTargets  *[]ScheduleTaskUpgradeTargets `json:"upgrade_targets,omitempty"`
 }
 
+func (s *ScheduleTask) GetAction() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Action
+}
+
+func (s *ScheduleTask) GetCronExpr() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.CronExpr
+}
+
+func (s *ScheduleTask) GetExecuteOnlyOnce() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ExecuteOnlyOnce
+}
+
+func (s *ScheduleTask) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *ScheduleTask) GetUpgradeTargets() []ScheduleTaskUpgradeTargets {
+	if s == nil || s.UpgradeTargets == nil {
+		return nil
+	}
+
+	return *s.UpgradeTargets
+}
+
 type ScheduleTaskUpgradeTargets struct {
 	Mac *string `json:"mac,omitempty"`
+}
+
+func (s *ScheduleTaskUpgradeTargets) GetMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Mac
 }

--- a/networkserver/tag.generated.go
+++ b/networkserver/tag.generated.go
@@ -21,3 +21,19 @@ type Tag struct {
 	MemberTable *[]string `json:"member_table,omitempty"`
 	Name        *string   `json:"name,omitempty"`
 }
+
+func (s *Tag) GetMemberTable() []string {
+	if s == nil || s.MemberTable == nil {
+		return nil
+	}
+
+	return *s.MemberTable
+}
+
+func (s *Tag) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}

--- a/networkserver/user.generated.go
+++ b/networkserver/user.generated.go
@@ -35,3 +35,131 @@ type User struct {
 	VirtualNetworkOverrideEnabled *bool   `json:"virtual_network_override_enabled,omitempty"`
 	VirtualNetworkOverrideId      *string `json:"virtual_network_override_id,omitempty"`
 }
+
+func (s *User) GetBlocked() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Blocked
+}
+
+func (s *User) GetFixedApEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.FixedApEnabled
+}
+
+func (s *User) GetFixedApMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.FixedApMac
+}
+
+func (s *User) GetFixedIp() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.FixedIp
+}
+
+func (s *User) GetHostname() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Hostname
+}
+
+func (s *User) GetLastSeen() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LastSeen
+}
+
+func (s *User) GetLocalDnsRecord() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LocalDnsRecord
+}
+
+func (s *User) GetLocalDnsRecordEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.LocalDnsRecordEnabled
+}
+
+func (s *User) GetMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Mac
+}
+
+func (s *User) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *User) GetNetworkId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NetworkId
+}
+
+func (s *User) GetNote() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Note
+}
+
+func (s *User) GetUseFixedip() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UseFixedip
+}
+
+func (s *User) GetUsergroupId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UsergroupId
+}
+
+func (s *User) GetVirtualNetworkOverrideEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.VirtualNetworkOverrideEnabled
+}
+
+func (s *User) GetVirtualNetworkOverrideId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.VirtualNetworkOverrideId
+}

--- a/networkserver/user_group.generated.go
+++ b/networkserver/user_group.generated.go
@@ -22,3 +22,27 @@ type UserGroup struct {
 	QosRateMaxDown *int64  `json:"qos_rate_max_down,omitempty"`
 	QosRateMaxUp   *int64  `json:"qos_rate_max_up,omitempty"`
 }
+
+func (s *UserGroup) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *UserGroup) GetQosRateMaxDown() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.QosRateMaxDown
+}
+
+func (s *UserGroup) GetQosRateMaxUp() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.QosRateMaxUp
+}

--- a/networkserver/wlan_conf.generated.go
+++ b/networkserver/wlan_conf.generated.go
@@ -110,6 +110,726 @@ type WlanConf struct {
 	XWep                        *string                         `json:"x_wep,omitempty"`
 }
 
+func (s *WlanConf) GetApGroupIds() []string {
+	if s == nil || s.ApGroupIds == nil {
+		return nil
+	}
+
+	return *s.ApGroupIds
+}
+
+func (s *WlanConf) GetApGroupMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ApGroupMode
+}
+
+func (s *WlanConf) GetAuthCache() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.AuthCache
+}
+
+func (s *WlanConf) GetBSupported() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.BSupported
+}
+
+func (s *WlanConf) GetBcFilterEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.BcFilterEnabled
+}
+
+func (s *WlanConf) GetBcFilterList() []string {
+	if s == nil || s.BcFilterList == nil {
+		return nil
+	}
+
+	return *s.BcFilterList
+}
+
+func (s *WlanConf) GetBssTransition() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.BssTransition
+}
+
+func (s *WlanConf) GetCountryBeacon() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.CountryBeacon
+}
+
+func (s *WlanConf) GetDpiEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.DpiEnabled
+}
+
+func (s *WlanConf) GetDpigroupId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DpigroupId
+}
+
+func (s *WlanConf) GetDtim6E() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Dtim6E
+}
+
+func (s *WlanConf) GetDtimMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.DtimMode
+}
+
+func (s *WlanConf) GetDtimNa() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DtimNa
+}
+
+func (s *WlanConf) GetDtimNg() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DtimNg
+}
+
+func (s *WlanConf) GetElementAdopt() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ElementAdopt
+}
+
+func (s *WlanConf) GetEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Enabled
+}
+
+func (s *WlanConf) GetFastRoamingEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.FastRoamingEnabled
+}
+
+func (s *WlanConf) GetGroupRekey() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.GroupRekey
+}
+
+func (s *WlanConf) GetHideSsid() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.HideSsid
+}
+
+func (s *WlanConf) GetHotspot2() *WlanConfHotspot2 {
+	if s == nil || s.Hotspot2 == nil {
+		return nil
+	}
+
+	return s.Hotspot2
+}
+
+func (s *WlanConf) GetHotspot2ConfEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hotspot2ConfEnabled
+}
+
+func (s *WlanConf) GetIappEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IappEnabled
+}
+
+func (s *WlanConf) GetIsGuest() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.IsGuest
+}
+
+func (s *WlanConf) GetL2Isolation() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.L2Isolation
+}
+
+func (s *WlanConf) GetLogLevel() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.LogLevel
+}
+
+func (s *WlanConf) GetMacFilterEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MacFilterEnabled
+}
+
+func (s *WlanConf) GetMacFilterList() []string {
+	if s == nil || s.MacFilterList == nil {
+		return nil
+	}
+
+	return *s.MacFilterList
+}
+
+func (s *WlanConf) GetMacFilterPolicy() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.MacFilterPolicy
+}
+
+func (s *WlanConf) GetMcastenhanceEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.McastenhanceEnabled
+}
+
+func (s *WlanConf) GetMinrateNaAdvertisingRates() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MinrateNaAdvertisingRates
+}
+
+func (s *WlanConf) GetMinrateNaDataRateKbps() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MinrateNaDataRateKbps
+}
+
+func (s *WlanConf) GetMinrateNaEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MinrateNaEnabled
+}
+
+func (s *WlanConf) GetMinrateNgAdvertisingRates() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MinrateNgAdvertisingRates
+}
+
+func (s *WlanConf) GetMinrateNgDataRateKbps() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MinrateNgDataRateKbps
+}
+
+func (s *WlanConf) GetMinrateNgEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MinrateNgEnabled
+}
+
+func (s *WlanConf) GetMinrateSettingPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.MinrateSettingPreference
+}
+
+func (s *WlanConf) GetMloEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MloEnabled
+}
+
+func (s *WlanConf) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *WlanConf) GetNameCombineEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NameCombineEnabled
+}
+
+func (s *WlanConf) GetNameCombineSuffix() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NameCombineSuffix
+}
+
+func (s *WlanConf) GetNasIdentifier() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NasIdentifier
+}
+
+func (s *WlanConf) GetNasIdentifierType() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NasIdentifierType
+}
+
+func (s *WlanConf) GetNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NetworkconfId
+}
+
+func (s *WlanConf) GetNo2GhzOui() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.No2GhzOui
+}
+
+func (s *WlanConf) GetOptimizeIotWifiConnectivity() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.OptimizeIotWifiConnectivity
+}
+
+func (s *WlanConf) GetP2P() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.P2P
+}
+
+func (s *WlanConf) GetP2PCrossConnect() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.P2PCrossConnect
+}
+
+func (s *WlanConf) GetPmfCipher() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PmfCipher
+}
+
+func (s *WlanConf) GetPmfMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.PmfMode
+}
+
+func (s *WlanConf) GetPriority() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Priority
+}
+
+func (s *WlanConf) GetPrivatePresharedKeys() []WlanConfPrivatePresharedKeys {
+	if s == nil || s.PrivatePresharedKeys == nil {
+		return nil
+	}
+
+	return *s.PrivatePresharedKeys
+}
+
+func (s *WlanConf) GetPrivatePresharedKeysEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.PrivatePresharedKeysEnabled
+}
+
+func (s *WlanConf) GetProxyArp() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ProxyArp
+}
+
+func (s *WlanConf) GetRadiusDasEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.RadiusDasEnabled
+}
+
+func (s *WlanConf) GetRadiusMacAuthEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.RadiusMacAuthEnabled
+}
+
+func (s *WlanConf) GetRadiusMacaclEmptyPassword() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.RadiusMacaclEmptyPassword
+}
+
+func (s *WlanConf) GetRadiusMacaclFormat() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.RadiusMacaclFormat
+}
+
+func (s *WlanConf) GetRadiusprofileId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.RadiusprofileId
+}
+
+func (s *WlanConf) GetRoamClusterId() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.RoamClusterId
+}
+
+func (s *WlanConf) GetRrmEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.RrmEnabled
+}
+
+func (s *WlanConf) GetSaeAntiClogging() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.SaeAntiClogging
+}
+
+func (s *WlanConf) GetSaeGroups() []int64 {
+	if s == nil || s.SaeGroups == nil {
+		return nil
+	}
+
+	return *s.SaeGroups
+}
+
+func (s *WlanConf) GetSaePsk() []WlanConfSaePsk {
+	if s == nil || s.SaePsk == nil {
+		return nil
+	}
+
+	return *s.SaePsk
+}
+
+func (s *WlanConf) GetSaePskVlanRequired() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.SaePskVlanRequired
+}
+
+func (s *WlanConf) GetSaeSync() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.SaeSync
+}
+
+func (s *WlanConf) GetSchedule() []string {
+	if s == nil || s.Schedule == nil {
+		return nil
+	}
+
+	return *s.Schedule
+}
+
+func (s *WlanConf) GetScheduleEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ScheduleEnabled
+}
+
+func (s *WlanConf) GetScheduleReversed() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.ScheduleReversed
+}
+
+func (s *WlanConf) GetScheduleWithDuration() []WlanConfScheduleWithDuration {
+	if s == nil || s.ScheduleWithDuration == nil {
+		return nil
+	}
+
+	return *s.ScheduleWithDuration
+}
+
+func (s *WlanConf) GetSecurity() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Security
+}
+
+func (s *WlanConf) GetSettingPreference() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SettingPreference
+}
+
+func (s *WlanConf) GetTdlsProhibit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.TdlsProhibit
+}
+
+func (s *WlanConf) GetUapsdEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.UapsdEnabled
+}
+
+func (s *WlanConf) GetUidWorkspaceUrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UidWorkspaceUrl
+}
+
+func (s *WlanConf) GetUsergroupId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.UsergroupId
+}
+
+func (s *WlanConf) GetVlan() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Vlan
+}
+
+func (s *WlanConf) GetVlanEnabled() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.VlanEnabled
+}
+
+func (s *WlanConf) GetWepIdx() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.WepIdx
+}
+
+func (s *WlanConf) GetWlanBand() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WlanBand
+}
+
+func (s *WlanConf) GetWlanBands() []string {
+	if s == nil || s.WlanBands == nil {
+		return nil
+	}
+
+	return *s.WlanBands
+}
+
+func (s *WlanConf) GetWpa3Enhanced192() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Wpa3Enhanced192
+}
+
+func (s *WlanConf) GetWpa3FastRoaming() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Wpa3FastRoaming
+}
+
+func (s *WlanConf) GetWpa3Support() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Wpa3Support
+}
+
+func (s *WlanConf) GetWpa3Transition() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Wpa3Transition
+}
+
+func (s *WlanConf) GetWpaEnc() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WpaEnc
+}
+
+func (s *WlanConf) GetWpaMode() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WpaMode
+}
+
+func (s *WlanConf) GetWpaPskRadius() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.WpaPskRadius
+}
+
+func (s *WlanConf) GetXIappKey() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XIappKey
+}
+
+func (s *WlanConf) GetXPassphrase() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XPassphrase
+}
+
+func (s *WlanConf) GetXWep() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.XWep
+}
+
 type WlanConfHotspot2 struct {
 	Capab                   *[]WlanConfHotspot2Capab                 `json:"capab,omitempty"`
 	CellularNetworkList     *[]WlanConfHotspot2CellularNetworkList   `json:"cellular_network_list,omitempty"`
@@ -139,10 +859,242 @@ type WlanConfHotspot2 struct {
 	VenueType               *float64                                 `json:"venue_type,omitempty"`
 }
 
+func (s *WlanConfHotspot2) GetCapab() []WlanConfHotspot2Capab {
+	if s == nil || s.Capab == nil {
+		return nil
+	}
+
+	return *s.Capab
+}
+
+func (s *WlanConfHotspot2) GetCellularNetworkList() []WlanConfHotspot2CellularNetworkList {
+	if s == nil || s.CellularNetworkList == nil {
+		return nil
+	}
+
+	return *s.CellularNetworkList
+}
+
+func (s *WlanConfHotspot2) GetDomainNameList() []string {
+	if s == nil || s.DomainNameList == nil {
+		return nil
+	}
+
+	return *s.DomainNameList
+}
+
+func (s *WlanConfHotspot2) GetFriendlyName() []WlanConfHotspot2FriendlyName {
+	if s == nil || s.FriendlyName == nil {
+		return nil
+	}
+
+	return *s.FriendlyName
+}
+
+func (s *WlanConfHotspot2) GetIpaddrTypeAvailV4() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpaddrTypeAvailV4
+}
+
+func (s *WlanConfHotspot2) GetIpaddrTypeAvailV6() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.IpaddrTypeAvailV6
+}
+
+func (s *WlanConfHotspot2) GetMetricsDownlinkLoad() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsDownlinkLoad
+}
+
+func (s *WlanConfHotspot2) GetMetricsDownlinkLoadSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsDownlinkLoadSet
+}
+
+func (s *WlanConfHotspot2) GetMetricsDownlinkSpeed() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsDownlinkSpeed
+}
+
+func (s *WlanConfHotspot2) GetMetricsDownlinkSpeedSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsDownlinkSpeedSet
+}
+
+func (s *WlanConfHotspot2) GetMetricsInfoAtCapacity() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsInfoAtCapacity
+}
+
+func (s *WlanConfHotspot2) GetMetricsInfoLinkStatus() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.MetricsInfoLinkStatus
+}
+
+func (s *WlanConfHotspot2) GetMetricsInfoSymmetric() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsInfoSymmetric
+}
+
+func (s *WlanConfHotspot2) GetMetricsMeasurement() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsMeasurement
+}
+
+func (s *WlanConfHotspot2) GetMetricsMeasurementSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsMeasurementSet
+}
+
+func (s *WlanConfHotspot2) GetMetricsStatus() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsStatus
+}
+
+func (s *WlanConfHotspot2) GetMetricsUplinkLoad() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsUplinkLoad
+}
+
+func (s *WlanConfHotspot2) GetMetricsUplinkLoadSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsUplinkLoadSet
+}
+
+func (s *WlanConfHotspot2) GetMetricsUplinkSpeed() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.MetricsUplinkSpeed
+}
+
+func (s *WlanConfHotspot2) GetMetricsUplinkSpeedSet() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.MetricsUplinkSpeedSet
+}
+
+func (s *WlanConfHotspot2) GetNaiRealmList() []WlanConfHotspot2NaiRealmList {
+	if s == nil || s.NaiRealmList == nil {
+		return nil
+	}
+
+	return *s.NaiRealmList
+}
+
+func (s *WlanConfHotspot2) GetNetworkType() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.NetworkType
+}
+
+func (s *WlanConfHotspot2) GetRoamingConsortiumList() []WlanConfHotspot2RoamingConsortiumList {
+	if s == nil || s.RoamingConsortiumList == nil {
+		return nil
+	}
+
+	return *s.RoamingConsortiumList
+}
+
+func (s *WlanConfHotspot2) GetVenueGroup() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.VenueGroup
+}
+
+func (s *WlanConfHotspot2) GetVenueName() []WlanConfHotspot2VenueName {
+	if s == nil || s.VenueName == nil {
+		return nil
+	}
+
+	return *s.VenueName
+}
+
+func (s *WlanConfHotspot2) GetVenueType() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.VenueType
+}
+
 type WlanConfHotspot2Capab struct {
 	Port     *float64 `json:"port,omitempty"`
 	Protocol *string  `json:"protocol,omitempty"`
 	Status   *string  `json:"status,omitempty"`
+}
+
+func (s *WlanConfHotspot2Capab) GetPort() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Port
+}
+
+func (s *WlanConfHotspot2Capab) GetProtocol() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Protocol
+}
+
+func (s *WlanConfHotspot2Capab) GetStatus() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Status
 }
 
 type WlanConfHotspot2CellularNetworkList struct {
@@ -152,9 +1104,57 @@ type WlanConfHotspot2CellularNetworkList struct {
 	Name        *string `json:"name,omitempty"`
 }
 
+func (s *WlanConfHotspot2CellularNetworkList) GetCountryCode() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.CountryCode
+}
+
+func (s *WlanConfHotspot2CellularNetworkList) GetMcc() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Mcc
+}
+
+func (s *WlanConfHotspot2CellularNetworkList) GetMnc() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Mnc
+}
+
+func (s *WlanConfHotspot2CellularNetworkList) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
 type WlanConfHotspot2FriendlyName struct {
 	Language *string `json:"language,omitempty"`
 	Text     *string `json:"text,omitempty"`
+}
+
+func (s *WlanConfHotspot2FriendlyName) GetLanguage() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Language
+}
+
+func (s *WlanConfHotspot2FriendlyName) GetText() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Text
 }
 
 type WlanConfHotspot2NaiRealmList struct {
@@ -166,9 +1166,73 @@ type WlanConfHotspot2NaiRealmList struct {
 	Status    *bool    `json:"status,omitempty"`
 }
 
+func (s *WlanConfHotspot2NaiRealmList) GetAuthIds() []int64 {
+	if s == nil || s.AuthIds == nil {
+		return nil
+	}
+
+	return *s.AuthIds
+}
+
+func (s *WlanConfHotspot2NaiRealmList) GetAuthVals() []int64 {
+	if s == nil || s.AuthVals == nil {
+		return nil
+	}
+
+	return *s.AuthVals
+}
+
+func (s *WlanConfHotspot2NaiRealmList) GetEapMethod() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.EapMethod
+}
+
+func (s *WlanConfHotspot2NaiRealmList) GetEncoding() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Encoding
+}
+
+func (s *WlanConfHotspot2NaiRealmList) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *WlanConfHotspot2NaiRealmList) GetStatus() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Status
+}
+
 type WlanConfHotspot2RoamingConsortiumList struct {
 	Name *string `json:"name,omitempty"`
 	Oid  *string `json:"oid,omitempty"`
+}
+
+func (s *WlanConfHotspot2RoamingConsortiumList) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *WlanConfHotspot2RoamingConsortiumList) GetOid() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Oid
 }
 
 type WlanConfHotspot2VenueName struct {
@@ -177,9 +1241,49 @@ type WlanConfHotspot2VenueName struct {
 	Url      *string `json:"url,omitempty"`
 }
 
+func (s *WlanConfHotspot2VenueName) GetLanguage() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Language
+}
+
+func (s *WlanConfHotspot2VenueName) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *WlanConfHotspot2VenueName) GetUrl() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Url
+}
+
 type WlanConfPrivatePresharedKeys struct {
 	NetworkconfId *string `json:"networkconf_id,omitempty"`
 	Password      *string `json:"password,omitempty"`
+}
+
+func (s *WlanConfPrivatePresharedKeys) GetNetworkconfId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.NetworkconfId
+}
+
+func (s *WlanConfPrivatePresharedKeys) GetPassword() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Password
 }
 
 type WlanConfSaePsk struct {
@@ -189,10 +1293,82 @@ type WlanConfSaePsk struct {
 	Vlan *float64 `json:"vlan,omitempty"`
 }
 
+func (s *WlanConfSaePsk) GetId() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Id
+}
+
+func (s *WlanConfSaePsk) GetMac() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Mac
+}
+
+func (s *WlanConfSaePsk) GetPsk() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Psk
+}
+
+func (s *WlanConfSaePsk) GetVlan() float64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.Vlan
+}
+
 type WlanConfScheduleWithDuration struct {
 	DurationMinutes *int64    `json:"duration_minutes,omitempty"`
 	Name            *string   `json:"name,omitempty"`
 	StartDaysOfWeek *[]string `json:"start_days_of_week,omitempty"`
 	StartHour       *int64    `json:"start_hour,omitempty"`
 	StartMinute     *int64    `json:"start_minute,omitempty"`
+}
+
+func (s *WlanConfScheduleWithDuration) GetDurationMinutes() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.DurationMinutes
+}
+
+func (s *WlanConfScheduleWithDuration) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}
+
+func (s *WlanConfScheduleWithDuration) GetStartDaysOfWeek() []string {
+	if s == nil || s.StartDaysOfWeek == nil {
+		return nil
+	}
+
+	return *s.StartDaysOfWeek
+}
+
+func (s *WlanConfScheduleWithDuration) GetStartHour() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StartHour
+}
+
+func (s *WlanConfScheduleWithDuration) GetStartMinute() int64 {
+	if s == nil {
+		return 0
+	}
+
+	return *s.StartMinute
 }

--- a/networkserver/wlan_group.generated.go
+++ b/networkserver/wlan_group.generated.go
@@ -20,3 +20,11 @@ package networkserver
 type WlanGroup struct {
 	Name *string `json:"name,omitempty"`
 }
+
+func (s *WlanGroup) GetName() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.Name
+}


### PR DESCRIPTION
These are convenience accessors that help when chaining lookups for nested objects. These are influenced in design by [go-github](https://github.com/google/go-github/blob/3d410c20b3a7e4496f5b86b7d85c0a51dbaf782e/github/github-accessors.go).