### PR TITLE
Add root object fields

### DIFF
--- a/internal/client-gen/api/endpoint.go
+++ b/internal/client-gen/api/endpoint.go
@@ -34,7 +34,7 @@ type Endpoint struct {
 }
 
 func NewEndpoint(name string, spec map[string]interface{}) (*Endpoint, error) {
-	rootObject, err := NewEndpointObject(name, spec, "")
+	rootObject, err := NewEndpointObject(name, spec, "", true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate objects for endpoint: %w", err)
 	}

--- a/internal/client-gen/api/endpoint_object.go
+++ b/internal/client-gen/api/endpoint_object.go
@@ -24,9 +24,10 @@ import (
 type EndpointObject struct {
 	Name   string
 	Fields []FieldDefinition
+	Root   bool
 }
 
-func NewEndpointObject(name string, values map[string]interface{}, namePrefix string) (*EndpointObject, error) {
+func NewEndpointObject(name string, values map[string]interface{}, namePrefix string, rootObject bool) (*EndpointObject, error) {
 	name = namePrefix + name
 	var fields []FieldDefinition
 	var errs []error
@@ -49,6 +50,7 @@ func NewEndpointObject(name string, values map[string]interface{}, namePrefix st
 	return &EndpointObject{
 		Name:   name,
 		Fields: fields,
+		Root:   rootObject,
 	}, nil
 }
 

--- a/internal/client-gen/api/endpoint_object_test.go
+++ b/internal/client-gen/api/endpoint_object_test.go
@@ -25,6 +25,7 @@ func TestNewEndpointObject(t *testing.T) {
 		name       string
 		namePrefix string
 		values     map[string]interface{}
+		rootObject bool
 
 		error bool
 		want  *EndpointObject
@@ -158,7 +159,7 @@ func TestNewEndpointObject(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got, err := NewEndpointObject(test.name, test.values, test.namePrefix)
+			got, err := NewEndpointObject(test.name, test.values, test.namePrefix, test.rootObject)
 			if test.error {
 				assert.Error(t, err)
 			} else {

--- a/internal/client-gen/api/field.go
+++ b/internal/client-gen/api/field.go
@@ -99,7 +99,7 @@ func fieldTypeFromInterfaceValue(jsonName, endpointObjectName string, value []in
 func fieldTypeFromObjectValue(jsonName, endpointObjectName string, values map[string]interface{}) (FieldType, *EndpointObject, error) {
 	name := strcase.ToCamel(jsonName)
 	fieldType := Object(endpointObjectName + name)
-	object, err := NewEndpointObject(name, values, endpointObjectName)
+	object, err := NewEndpointObject(name, values, endpointObjectName, false)
 	if err != nil {
 		return FieldType{}, nil, fmt.Errorf("failed to create endpoint object for field: %w", err)
 	}

--- a/internal/client-gen/api/templates/struct.gotmpl
+++ b/internal/client-gen/api/templates/struct.gotmpl
@@ -1,4 +1,13 @@
 type {{ .Name }} struct {
+	{{ if .Root }}
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+	{{ end }}
 	{{- range $field := .Fields }}
 	{{ $field.Name }} *{{ $field.Type.GoType }} `json:"{{ $field.JSONName}},omitempty"`
 	{{- end }}

--- a/networkserver/account.generated.go
+++ b/networkserver/account.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type Account struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Ip               *string `json:"ip,omitempty"`
 	Name             *string `json:"name,omitempty"`
 	NetworkconfId    *string `json:"networkconf_id,omitempty"`

--- a/networkserver/broadcast_group.generated.go
+++ b/networkserver/broadcast_group.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type BroadcastGroup struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	MemberTable *[]string `json:"member_table,omitempty"`
 	Name        *string   `json:"name,omitempty"`
 }

--- a/networkserver/channel_plan.generated.go
+++ b/networkserver/channel_plan.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type ChannelPlan struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	ApBlacklistedChannels   *[]ChannelPlanApBlacklistedChannels   `json:"ap_blacklisted_channels,omitempty"`
 	ConfSource              *string                               `json:"conf_source,omitempty"`
 	Coupling                *[]ChannelPlanCoupling                `json:"coupling,omitempty"`

--- a/networkserver/dashboard.generated.go
+++ b/networkserver/dashboard.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type Dashboard struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	ControllerVersion *string             `json:"controller_version,omitempty"`
 	Desc              *string             `json:"desc,omitempty"`
 	IsPublic          *bool               `json:"is_public,omitempty"`

--- a/networkserver/device.generated.go
+++ b/networkserver/device.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type Device struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	AtfEnabled                  *bool                      `json:"atf_enabled,omitempty"`
 	BandsteeringMode            *string                    `json:"bandsteering_mode,omitempty"`
 	BaresipAuthUser             *string                    `json:"baresip_auth_user,omitempty"`

--- a/networkserver/dhcp_option.generated.go
+++ b/networkserver/dhcp_option.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type DhcpOption struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Code   *string `json:"code,omitempty"`
 	Name   *string `json:"name,omitempty"`
 	Signed *bool   `json:"signed,omitempty"`

--- a/networkserver/dpi_app.generated.go
+++ b/networkserver/dpi_app.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type DpiApp struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Apps           *[]int64 `json:"apps,omitempty"`
 	Blocked        *bool    `json:"blocked,omitempty"`
 	Cats           *[]int64 `json:"cats,omitempty"`

--- a/networkserver/dpi_group.generated.go
+++ b/networkserver/dpi_group.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type DpiGroup struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	DpiappIds *[]string `json:"dpiapp_ids,omitempty"`
 	Enabled   *bool     `json:"enabled,omitempty"`
 	Name      *string   `json:"name,omitempty"`

--- a/networkserver/dynamic_dns.generated.go
+++ b/networkserver/dynamic_dns.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type DynamicDNS struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	CustomService *string   `json:"custom_service,omitempty"`
 	HostName      *string   `json:"host_name,omitempty"`
 	Interface     *string   `json:"interface,omitempty"`

--- a/networkserver/firewall_group.generated.go
+++ b/networkserver/firewall_group.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type FirewallGroup struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	GroupMembers *[]string `json:"group_members,omitempty"`
 	GroupType    *string   `json:"group_type,omitempty"`
 	Name         *string   `json:"name,omitempty"`

--- a/networkserver/firewall_rule.generated.go
+++ b/networkserver/firewall_rule.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type FirewallRule struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Action                *string   `json:"action,omitempty"`
 	Contiguous            *bool     `json:"contiguous,omitempty"`
 	DstAddress            *string   `json:"dst_address,omitempty"`

--- a/networkserver/hotspot_2_conf.generated.go
+++ b/networkserver/hotspot_2_conf.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type Hotspot2Conf struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	AnqpDomainId            *float64                             `json:"anqp_domain_id,omitempty"`
 	Capab                   *[]Hotspot2ConfCapab                 `json:"capab,omitempty"`
 	CellularNetworkList     *[]Hotspot2ConfCellularNetworkList   `json:"cellular_network_list,omitempty"`

--- a/networkserver/hotspot_op.generated.go
+++ b/networkserver/hotspot_op.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type HotspotOp struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Name      *string `json:"name,omitempty"`
 	Note      *string `json:"note,omitempty"`
 	XPassword *string `json:"x_password,omitempty"`

--- a/networkserver/hotspot_package.generated.go
+++ b/networkserver/hotspot_package.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type HotspotPackage struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Amount                         *float64 `json:"amount,omitempty"`
 	ChargedAs                      *string  `json:"charged_as,omitempty"`
 	Currency                       *string  `json:"currency,omitempty"`

--- a/networkserver/network_conf.generated.go
+++ b/networkserver/network_conf.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type NetworkConf struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	AutoScaleEnabled                              *bool                                `json:"auto_scale_enabled,omitempty"`
 	DhcpRelayEnabled                              *bool                                `json:"dhcp_relay_enabled,omitempty"`
 	DhcpdBootEnabled                              *bool                                `json:"dhcpd_boot_enabled,omitempty"`

--- a/networkserver/port_conf.generated.go
+++ b/networkserver/port_conf.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type PortConf struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Autoneg                       *bool               `json:"autoneg,omitempty"`
 	Dot1XCtrl                     *string             `json:"dot1x_ctrl,omitempty"`
 	Dot1XIdleTimeout              *float64            `json:"dot1x_idle_timeout,omitempty"`

--- a/networkserver/port_forward.generated.go
+++ b/networkserver/port_forward.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type PortForward struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	DestinationIp      *string                      `json:"destination_ip,omitempty"`
 	DestinationIps     *[]PortForwardDestinationIps `json:"destination_ips,omitempty"`
 	DstPort            *string                      `json:"dst_port,omitempty"`

--- a/networkserver/radius_profile.generated.go
+++ b/networkserver/radius_profile.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type RadiusProfile struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	AccountingEnabled         *bool                       `json:"accounting_enabled,omitempty"`
 	AcctServers               *[]RadiusProfileAcctServers `json:"acct_servers,omitempty"`
 	AuthServers               *[]RadiusProfileAuthServers `json:"auth_servers,omitempty"`

--- a/networkserver/routing.generated.go
+++ b/networkserver/routing.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type Routing struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Enabled              *bool   `json:"enabled,omitempty"`
 	GatewayDevice        *string `json:"gateway_device,omitempty"`
 	GatewayType          *string `json:"gateway_type,omitempty"`

--- a/networkserver/schedule_task.generated.go
+++ b/networkserver/schedule_task.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type ScheduleTask struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Action          *string                       `json:"action,omitempty"`
 	CronExpr        *string                       `json:"cron_expr,omitempty"`
 	ExecuteOnlyOnce *bool                         `json:"execute_only_once,omitempty"`

--- a/networkserver/tag.generated.go
+++ b/networkserver/tag.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type Tag struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	MemberTable *[]string `json:"member_table,omitempty"`
 	Name        *string   `json:"name,omitempty"`
 }

--- a/networkserver/user.generated.go
+++ b/networkserver/user.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type User struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Blocked                       *string `json:"blocked,omitempty"`
 	FixedApEnabled                *bool   `json:"fixed_ap_enabled,omitempty"`
 	FixedApMac                    *string `json:"fixed_ap_mac,omitempty"`

--- a/networkserver/user_group.generated.go
+++ b/networkserver/user_group.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type UserGroup struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Name           *string `json:"name,omitempty"`
 	QosRateMaxDown *int64  `json:"qos_rate_max_down,omitempty"`
 	QosRateMaxUp   *int64  `json:"qos_rate_max_up,omitempty"`

--- a/networkserver/wlan_conf.generated.go
+++ b/networkserver/wlan_conf.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type WlanConf struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	ApGroupIds                  *[]string                       `json:"ap_group_ids,omitempty"`
 	ApGroupMode                 *string                         `json:"ap_group_mode,omitempty"`
 	AuthCache                   *bool                           `json:"auth_cache,omitempty"`

--- a/networkserver/wlan_group.generated.go
+++ b/networkserver/wlan_group.generated.go
@@ -18,6 +18,14 @@
 package networkserver
 
 type WlanGroup struct {
+	ID     *string `json:"_id,omitempty"`
+	SiteID *string `json:"site_id,omitempty"`
+
+	Hidden   *bool   `json:"attr_hidden,omitempty"`
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	NoDelete *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+
 	Name *string `json:"name,omitempty"`
 }
 


### PR DESCRIPTION
Root objects for an endpoint have an extra set of fields. Some of these are obvious, i.e. `ID` and `SiteID`, whilst other are less obvious. 

The `Hidden`, `HiddenID`, `NoDelete` and `NoEdit` are all attributes that can exist on an endpoint object, but are generally not displayed to a user. Most of the time this exist on "default" entities in the Unifi Network Server, e.g. the default WAN or LAN. They are added for informational purposes only.