### PR TITLE
Add accessors for root object fields

### DIFF
--- a/internal/client-gen/api/endpoint_object.go
+++ b/internal/client-gen/api/endpoint_object.go
@@ -21,10 +21,42 @@ import (
 	"slices"
 )
 
+var rootObjectFields = []FieldDefinition{
+	{
+		Name:     "ID",
+		JSONName: "_id",
+		Type:     String,
+	},
+	{
+		Name:     "SiteID",
+		JSONName: "site_id",
+		Type:     String,
+	},
+	{
+		Name:     "Hidden",
+		JSONName: "attr_hidden",
+		Type:     Boolean,
+	},
+	{
+		Name:     "HiddenID",
+		JSONName: "attr_hidden_id",
+		Type:     String,
+	},
+	{
+		Name:     "NoDelete",
+		JSONName: "attr_no_delete",
+		Type:     Boolean,
+	},
+	{
+		Name:     "NoEdit",
+		JSONName: "attr_no_edit",
+		Type:     Boolean,
+	},
+}
+
 type EndpointObject struct {
 	Name   string
 	Fields []FieldDefinition
-	Root   bool
 }
 
 func NewEndpointObject(name string, values map[string]interface{}, namePrefix string, rootObject bool) (*EndpointObject, error) {
@@ -47,10 +79,13 @@ func NewEndpointObject(name string, values map[string]interface{}, namePrefix st
 		return nil, fmt.Errorf("invalid field definitions for endpoint object: %w", errors.Join(errs...))
 	}
 
+	if rootObject {
+		fields = append(rootObjectFields, fields...)
+	}
+
 	return &EndpointObject{
 		Name:   name,
 		Fields: fields,
-		Root:   rootObject,
 	}, nil
 }
 

--- a/internal/client-gen/api/templates/file.gotmpl
+++ b/internal/client-gen/api/templates/file.gotmpl
@@ -107,7 +107,7 @@ func (c *Client) List{{ .Name }}(ctx context.Context, site string) ([]{{ .Name }
 }
 
 func (c *Client) Update{{ .Name }}(ctx context.Context, site string, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
-    endpointPath:= path.Join("api/s/",site, "rest", "{{ .APIPath }}", *data.ID)
+    endpointPath:= path.Join("api/s/",site, "rest", "{{ .APIPath }}", data.GetID())
     req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
     if err != nil {
         return nil, nil, err

--- a/internal/client-gen/api/templates/struct.gotmpl
+++ b/internal/client-gen/api/templates/struct.gotmpl
@@ -1,13 +1,4 @@
 type {{ .Name }} struct {
-	{{ if .Root }}
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-	{{ end }}
 	{{- range $field := .Fields }}
 	{{ $field.Name }} *{{ $field.Type.GoType }} `json:"{{ $field.JSONName}},omitempty"`
 	{{- end }}

--- a/networkserver/account.generated.go
+++ b/networkserver/account.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type Account struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID               *string `json:"_id,omitempty"`
+	SiteID           *string `json:"site_id,omitempty"`
+	Hidden           *bool   `json:"attr_hidden,omitempty"`
+	HiddenID         *string `json:"attr_hidden_id,omitempty"`
+	NoDelete         *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit           *bool   `json:"attr_no_edit,omitempty"`
 	Ip               *string `json:"ip,omitempty"`
 	Name             *string `json:"name,omitempty"`
 	NetworkconfId    *string `json:"networkconf_id,omitempty"`
@@ -43,6 +41,54 @@ type Account struct {
 	TunnelType       *int64  `json:"tunnel_type,omitempty"`
 	Vlan             *int64  `json:"vlan,omitempty"`
 	XPassword        *string `json:"x_password,omitempty"`
+}
+
+func (s *Account) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *Account) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *Account) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *Account) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *Account) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *Account) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *Account) GetIp() string {
@@ -153,7 +199,7 @@ func (c *Client) DeleteAccount(ctx context.Context, site string, id string) (*ht
 		return resp, fmt.Errorf(`unable to delete Account: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetAccount(ctx context.Context, site, id string) (*Account, *http.Response, error) {
@@ -198,7 +244,7 @@ func (c *Client) ListAccount(ctx context.Context, site string) ([]Account, *http
 }
 
 func (c *Client) UpdateAccount(ctx context.Context, site string, data *Account) (*Account, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "account", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "account", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/broadcast_group.generated.go
+++ b/networkserver/broadcast_group.generated.go
@@ -27,16 +27,62 @@ import (
 )
 
 type BroadcastGroup struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID          *string   `json:"_id,omitempty"`
+	SiteID      *string   `json:"site_id,omitempty"`
+	Hidden      *bool     `json:"attr_hidden,omitempty"`
+	HiddenID    *string   `json:"attr_hidden_id,omitempty"`
+	NoDelete    *bool     `json:"attr_no_delete,omitempty"`
+	NoEdit      *bool     `json:"attr_no_edit,omitempty"`
 	MemberTable *[]string `json:"member_table,omitempty"`
 	Name        *string   `json:"name,omitempty"`
+}
+
+func (s *BroadcastGroup) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *BroadcastGroup) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *BroadcastGroup) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *BroadcastGroup) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *BroadcastGroup) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *BroadcastGroup) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *BroadcastGroup) GetMemberTable() []string {
@@ -99,7 +145,7 @@ func (c *Client) DeleteBroadcastGroup(ctx context.Context, site string, id strin
 		return resp, fmt.Errorf(`unable to delete BroadcastGroup: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetBroadcastGroup(ctx context.Context, site, id string) (*BroadcastGroup, *http.Response, error) {
@@ -144,7 +190,7 @@ func (c *Client) ListBroadcastGroup(ctx context.Context, site string) ([]Broadca
 }
 
 func (c *Client) UpdateBroadcastGroup(ctx context.Context, site string, data *BroadcastGroup) (*BroadcastGroup, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "broadcastgroup", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "broadcastgroup", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/channel_plan.generated.go
+++ b/networkserver/channel_plan.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type ChannelPlan struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                      *string                               `json:"_id,omitempty"`
+	SiteID                  *string                               `json:"site_id,omitempty"`
+	Hidden                  *bool                                 `json:"attr_hidden,omitempty"`
+	HiddenID                *string                               `json:"attr_hidden_id,omitempty"`
+	NoDelete                *bool                                 `json:"attr_no_delete,omitempty"`
+	NoEdit                  *bool                                 `json:"attr_no_edit,omitempty"`
 	ApBlacklistedChannels   *[]ChannelPlanApBlacklistedChannels   `json:"ap_blacklisted_channels,omitempty"`
 	ConfSource              *string                               `json:"conf_source,omitempty"`
 	Coupling                *[]ChannelPlanCoupling                `json:"coupling,omitempty"`
@@ -46,6 +44,54 @@ type ChannelPlan struct {
 	Satisfaction            *string                               `json:"satisfaction,omitempty"`
 	SatisfactionTable       *[]ChannelPlanSatisfactionTable       `json:"satisfaction_table,omitempty"`
 	SiteBlacklistedChannels *[]ChannelPlanSiteBlacklistedChannels `json:"site_blacklisted_channels,omitempty"`
+}
+
+func (s *ChannelPlan) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *ChannelPlan) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *ChannelPlan) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *ChannelPlan) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *ChannelPlan) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *ChannelPlan) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *ChannelPlan) GetApBlacklistedChannels() []ChannelPlanApBlacklistedChannels {
@@ -348,7 +394,7 @@ func (c *Client) DeleteChannelPlan(ctx context.Context, site string, id string) 
 		return resp, fmt.Errorf(`unable to delete ChannelPlan: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetChannelPlan(ctx context.Context, site, id string) (*ChannelPlan, *http.Response, error) {
@@ -393,7 +439,7 @@ func (c *Client) ListChannelPlan(ctx context.Context, site string) ([]ChannelPla
 }
 
 func (c *Client) UpdateChannelPlan(ctx context.Context, site string, data *ChannelPlan) (*ChannelPlan, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "channelplan", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "channelplan", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/dashboard.generated.go
+++ b/networkserver/dashboard.generated.go
@@ -27,19 +27,65 @@ import (
 )
 
 type Dashboard struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                *string             `json:"_id,omitempty"`
+	SiteID            *string             `json:"site_id,omitempty"`
+	Hidden            *bool               `json:"attr_hidden,omitempty"`
+	HiddenID          *string             `json:"attr_hidden_id,omitempty"`
+	NoDelete          *bool               `json:"attr_no_delete,omitempty"`
+	NoEdit            *bool               `json:"attr_no_edit,omitempty"`
 	ControllerVersion *string             `json:"controller_version,omitempty"`
 	Desc              *string             `json:"desc,omitempty"`
 	IsPublic          *bool               `json:"is_public,omitempty"`
 	Modules           *[]DashboardModules `json:"modules,omitempty"`
 	Name              *string             `json:"name,omitempty"`
+}
+
+func (s *Dashboard) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *Dashboard) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *Dashboard) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *Dashboard) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *Dashboard) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *Dashboard) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *Dashboard) GetControllerVersion() string {
@@ -165,7 +211,7 @@ func (c *Client) DeleteDashboard(ctx context.Context, site string, id string) (*
 		return resp, fmt.Errorf(`unable to delete Dashboard: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetDashboard(ctx context.Context, site, id string) (*Dashboard, *http.Response, error) {
@@ -210,7 +256,7 @@ func (c *Client) ListDashboard(ctx context.Context, site string) ([]Dashboard, *
 }
 
 func (c *Client) UpdateDashboard(ctx context.Context, site string, data *Dashboard) (*Dashboard, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "dashboard", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "dashboard", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/device.generated.go
+++ b/networkserver/device.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type Device struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                          *string                    `json:"_id,omitempty"`
+	SiteID                      *string                    `json:"site_id,omitempty"`
+	Hidden                      *bool                      `json:"attr_hidden,omitempty"`
+	HiddenID                    *string                    `json:"attr_hidden_id,omitempty"`
+	NoDelete                    *bool                      `json:"attr_no_delete,omitempty"`
+	NoEdit                      *bool                      `json:"attr_no_edit,omitempty"`
 	AtfEnabled                  *bool                      `json:"atf_enabled,omitempty"`
 	BandsteeringMode            *string                    `json:"bandsteering_mode,omitempty"`
 	BaresipAuthUser             *string                    `json:"baresip_auth_user,omitempty"`
@@ -111,6 +109,54 @@ type Device struct {
 	X                           *string                    `json:"x,omitempty"`
 	XBaresipPassword            *string                    `json:"x_baresip_password,omitempty"`
 	Y                           *string                    `json:"y,omitempty"`
+}
+
+func (s *Device) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *Device) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *Device) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *Device) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *Device) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *Device) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *Device) GetAtfEnabled() bool {
@@ -1713,7 +1759,7 @@ func (c *Client) DeleteDevice(ctx context.Context, site string, id string) (*htt
 		return resp, fmt.Errorf(`unable to delete Device: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetDevice(ctx context.Context, site, id string) (*Device, *http.Response, error) {
@@ -1758,7 +1804,7 @@ func (c *Client) ListDevice(ctx context.Context, site string) ([]Device, *http.R
 }
 
 func (c *Client) UpdateDevice(ctx context.Context, site string, data *Device) (*Device, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "device", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "device", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/dhcp_option.generated.go
+++ b/networkserver/dhcp_option.generated.go
@@ -27,19 +27,65 @@ import (
 )
 
 type DhcpOption struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
+	ID       *string `json:"_id,omitempty"`
+	SiteID   *string `json:"site_id,omitempty"`
 	Hidden   *bool   `json:"attr_hidden,omitempty"`
 	HiddenID *string `json:"attr_hidden_id,omitempty"`
 	NoDelete *bool   `json:"attr_no_delete,omitempty"`
 	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+	Code     *string `json:"code,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Signed   *bool   `json:"signed,omitempty"`
+	Type     *string `json:"type,omitempty"`
+	Width    *int64  `json:"width,omitempty"`
+}
 
-	Code   *string `json:"code,omitempty"`
-	Name   *string `json:"name,omitempty"`
-	Signed *bool   `json:"signed,omitempty"`
-	Type   *string `json:"type,omitempty"`
-	Width  *int64  `json:"width,omitempty"`
+func (s *DhcpOption) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *DhcpOption) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *DhcpOption) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *DhcpOption) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *DhcpOption) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *DhcpOption) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *DhcpOption) GetCode() string {
@@ -126,7 +172,7 @@ func (c *Client) DeleteDhcpOption(ctx context.Context, site string, id string) (
 		return resp, fmt.Errorf(`unable to delete DhcpOption: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetDhcpOption(ctx context.Context, site, id string) (*DhcpOption, *http.Response, error) {
@@ -171,7 +217,7 @@ func (c *Client) ListDhcpOption(ctx context.Context, site string) ([]DhcpOption,
 }
 
 func (c *Client) UpdateDhcpOption(ctx context.Context, site string, data *DhcpOption) (*DhcpOption, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "dhcpoption", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "dhcpoption", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/dpi_app.generated.go
+++ b/networkserver/dpi_app.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type DpiApp struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID             *string  `json:"_id,omitempty"`
+	SiteID         *string  `json:"site_id,omitempty"`
+	Hidden         *bool    `json:"attr_hidden,omitempty"`
+	HiddenID       *string  `json:"attr_hidden_id,omitempty"`
+	NoDelete       *bool    `json:"attr_no_delete,omitempty"`
+	NoEdit         *bool    `json:"attr_no_edit,omitempty"`
 	Apps           *[]int64 `json:"apps,omitempty"`
 	Blocked        *bool    `json:"blocked,omitempty"`
 	Cats           *[]int64 `json:"cats,omitempty"`
@@ -43,6 +41,54 @@ type DpiApp struct {
 	Name           *string  `json:"name,omitempty"`
 	QosRateMaxDown *float64 `json:"qos_rate_max_down,omitempty"`
 	QosRateMaxUp   *float64 `json:"qos_rate_max_up,omitempty"`
+}
+
+func (s *DpiApp) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *DpiApp) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *DpiApp) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *DpiApp) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *DpiApp) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *DpiApp) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *DpiApp) GetApps() []int64 {
@@ -153,7 +199,7 @@ func (c *Client) DeleteDpiApp(ctx context.Context, site string, id string) (*htt
 		return resp, fmt.Errorf(`unable to delete DpiApp: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetDpiApp(ctx context.Context, site, id string) (*DpiApp, *http.Response, error) {
@@ -198,7 +244,7 @@ func (c *Client) ListDpiApp(ctx context.Context, site string) ([]DpiApp, *http.R
 }
 
 func (c *Client) UpdateDpiApp(ctx context.Context, site string, data *DpiApp) (*DpiApp, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "dpiapp", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "dpiapp", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/dpi_group.generated.go
+++ b/networkserver/dpi_group.generated.go
@@ -27,17 +27,63 @@ import (
 )
 
 type DpiGroup struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID        *string   `json:"_id,omitempty"`
+	SiteID    *string   `json:"site_id,omitempty"`
+	Hidden    *bool     `json:"attr_hidden,omitempty"`
+	HiddenID  *string   `json:"attr_hidden_id,omitempty"`
+	NoDelete  *bool     `json:"attr_no_delete,omitempty"`
+	NoEdit    *bool     `json:"attr_no_edit,omitempty"`
 	DpiappIds *[]string `json:"dpiapp_ids,omitempty"`
 	Enabled   *bool     `json:"enabled,omitempty"`
 	Name      *string   `json:"name,omitempty"`
+}
+
+func (s *DpiGroup) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *DpiGroup) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *DpiGroup) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *DpiGroup) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *DpiGroup) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *DpiGroup) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *DpiGroup) GetDpiappIds() []string {
@@ -108,7 +154,7 @@ func (c *Client) DeleteDpiGroup(ctx context.Context, site string, id string) (*h
 		return resp, fmt.Errorf(`unable to delete DpiGroup: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetDpiGroup(ctx context.Context, site, id string) (*DpiGroup, *http.Response, error) {
@@ -153,7 +199,7 @@ func (c *Client) ListDpiGroup(ctx context.Context, site string) ([]DpiGroup, *ht
 }
 
 func (c *Client) UpdateDpiGroup(ctx context.Context, site string, data *DpiGroup) (*DpiGroup, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "dpigroup", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "dpigroup", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/dynamic_dns.generated.go
+++ b/networkserver/dynamic_dns.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type DynamicDNS struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID            *string   `json:"_id,omitempty"`
+	SiteID        *string   `json:"site_id,omitempty"`
+	Hidden        *bool     `json:"attr_hidden,omitempty"`
+	HiddenID      *string   `json:"attr_hidden_id,omitempty"`
+	NoDelete      *bool     `json:"attr_no_delete,omitempty"`
+	NoEdit        *bool     `json:"attr_no_edit,omitempty"`
 	CustomService *string   `json:"custom_service,omitempty"`
 	HostName      *string   `json:"host_name,omitempty"`
 	Interface     *string   `json:"interface,omitempty"`
@@ -43,6 +41,54 @@ type DynamicDNS struct {
 	Server        *string   `json:"server,omitempty"`
 	Service       *string   `json:"service,omitempty"`
 	XPassword     *string   `json:"x_password,omitempty"`
+}
+
+func (s *DynamicDNS) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *DynamicDNS) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *DynamicDNS) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *DynamicDNS) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *DynamicDNS) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *DynamicDNS) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *DynamicDNS) GetCustomService() string {
@@ -153,7 +199,7 @@ func (c *Client) DeleteDynamicDNS(ctx context.Context, site string, id string) (
 		return resp, fmt.Errorf(`unable to delete DynamicDNS: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetDynamicDNS(ctx context.Context, site, id string) (*DynamicDNS, *http.Response, error) {
@@ -198,7 +244,7 @@ func (c *Client) ListDynamicDNS(ctx context.Context, site string) ([]DynamicDNS,
 }
 
 func (c *Client) UpdateDynamicDNS(ctx context.Context, site string, data *DynamicDNS) (*DynamicDNS, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "dynamicdns", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "dynamicdns", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/firewall_group.generated.go
+++ b/networkserver/firewall_group.generated.go
@@ -27,17 +27,63 @@ import (
 )
 
 type FirewallGroup struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID           *string   `json:"_id,omitempty"`
+	SiteID       *string   `json:"site_id,omitempty"`
+	Hidden       *bool     `json:"attr_hidden,omitempty"`
+	HiddenID     *string   `json:"attr_hidden_id,omitempty"`
+	NoDelete     *bool     `json:"attr_no_delete,omitempty"`
+	NoEdit       *bool     `json:"attr_no_edit,omitempty"`
 	GroupMembers *[]string `json:"group_members,omitempty"`
 	GroupType    *string   `json:"group_type,omitempty"`
 	Name         *string   `json:"name,omitempty"`
+}
+
+func (s *FirewallGroup) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *FirewallGroup) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *FirewallGroup) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *FirewallGroup) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *FirewallGroup) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *FirewallGroup) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *FirewallGroup) GetGroupMembers() []string {
@@ -108,7 +154,7 @@ func (c *Client) DeleteFirewallGroup(ctx context.Context, site string, id string
 		return resp, fmt.Errorf(`unable to delete FirewallGroup: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetFirewallGroup(ctx context.Context, site, id string) (*FirewallGroup, *http.Response, error) {
@@ -153,7 +199,7 @@ func (c *Client) ListFirewallGroup(ctx context.Context, site string) ([]Firewall
 }
 
 func (c *Client) UpdateFirewallGroup(ctx context.Context, site string, data *FirewallGroup) (*FirewallGroup, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "firewallgroup", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "firewallgroup", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/firewall_rule.generated.go
+++ b/networkserver/firewall_rule.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type FirewallRule struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                    *string   `json:"_id,omitempty"`
+	SiteID                *string   `json:"site_id,omitempty"`
+	Hidden                *bool     `json:"attr_hidden,omitempty"`
+	HiddenID              *string   `json:"attr_hidden_id,omitempty"`
+	NoDelete              *bool     `json:"attr_no_delete,omitempty"`
+	NoEdit                *bool     `json:"attr_no_edit,omitempty"`
 	Action                *string   `json:"action,omitempty"`
 	Contiguous            *bool     `json:"contiguous,omitempty"`
 	DstAddress            *string   `json:"dst_address,omitempty"`
@@ -75,6 +73,54 @@ type FirewallRule struct {
 	Utc                   *bool     `json:"utc,omitempty"`
 	Weekdays              *string   `json:"weekdays,omitempty"`
 	WeekdaysNegate        *bool     `json:"weekdays_negate,omitempty"`
+}
+
+func (s *FirewallRule) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *FirewallRule) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *FirewallRule) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *FirewallRule) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *FirewallRule) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *FirewallRule) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *FirewallRule) GetAction() string {
@@ -441,7 +487,7 @@ func (c *Client) DeleteFirewallRule(ctx context.Context, site string, id string)
 		return resp, fmt.Errorf(`unable to delete FirewallRule: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetFirewallRule(ctx context.Context, site, id string) (*FirewallRule, *http.Response, error) {
@@ -486,7 +532,7 @@ func (c *Client) ListFirewallRule(ctx context.Context, site string) ([]FirewallR
 }
 
 func (c *Client) UpdateFirewallRule(ctx context.Context, site string, data *FirewallRule) (*FirewallRule, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "firewallrule", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "firewallrule", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/hotspot_2_conf.generated.go
+++ b/networkserver/hotspot_2_conf.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type Hotspot2Conf struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                      *string                              `json:"_id,omitempty"`
+	SiteID                  *string                              `json:"site_id,omitempty"`
+	Hidden                  *bool                                `json:"attr_hidden,omitempty"`
+	HiddenID                *string                              `json:"attr_hidden_id,omitempty"`
+	NoDelete                *bool                                `json:"attr_no_delete,omitempty"`
+	NoEdit                  *bool                                `json:"attr_no_edit,omitempty"`
 	AnqpDomainId            *float64                             `json:"anqp_domain_id,omitempty"`
 	Capab                   *[]Hotspot2ConfCapab                 `json:"capab,omitempty"`
 	CellularNetworkList     *[]Hotspot2ConfCellularNetworkList   `json:"cellular_network_list,omitempty"`
@@ -85,6 +83,54 @@ type Hotspot2Conf struct {
 	VenueGroup              *int64                               `json:"venue_group,omitempty"`
 	VenueName               *[]Hotspot2ConfVenueName             `json:"venue_name,omitempty"`
 	VenueType               *float64                             `json:"venue_type,omitempty"`
+}
+
+func (s *Hotspot2Conf) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *Hotspot2Conf) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *Hotspot2Conf) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *Hotspot2Conf) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *Hotspot2Conf) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *Hotspot2Conf) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *Hotspot2Conf) GetAnqpDomainId() float64 {
@@ -975,7 +1021,7 @@ func (c *Client) DeleteHotspot2Conf(ctx context.Context, site string, id string)
 		return resp, fmt.Errorf(`unable to delete Hotspot2Conf: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetHotspot2Conf(ctx context.Context, site, id string) (*Hotspot2Conf, *http.Response, error) {
@@ -1020,7 +1066,7 @@ func (c *Client) ListHotspot2Conf(ctx context.Context, site string) ([]Hotspot2C
 }
 
 func (c *Client) UpdateHotspot2Conf(ctx context.Context, site string, data *Hotspot2Conf) (*Hotspot2Conf, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "hotspot2conf", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "hotspot2conf", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/hotspot_op.generated.go
+++ b/networkserver/hotspot_op.generated.go
@@ -27,17 +27,63 @@ import (
 )
 
 type HotspotOp struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID        *string `json:"_id,omitempty"`
+	SiteID    *string `json:"site_id,omitempty"`
+	Hidden    *bool   `json:"attr_hidden,omitempty"`
+	HiddenID  *string `json:"attr_hidden_id,omitempty"`
+	NoDelete  *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit    *bool   `json:"attr_no_edit,omitempty"`
 	Name      *string `json:"name,omitempty"`
 	Note      *string `json:"note,omitempty"`
 	XPassword *string `json:"x_password,omitempty"`
+}
+
+func (s *HotspotOp) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *HotspotOp) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *HotspotOp) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *HotspotOp) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *HotspotOp) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *HotspotOp) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *HotspotOp) GetName() string {
@@ -108,7 +154,7 @@ func (c *Client) DeleteHotspotOp(ctx context.Context, site string, id string) (*
 		return resp, fmt.Errorf(`unable to delete HotspotOp: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetHotspotOp(ctx context.Context, site, id string) (*HotspotOp, *http.Response, error) {
@@ -153,7 +199,7 @@ func (c *Client) ListHotspotOp(ctx context.Context, site string) ([]HotspotOp, *
 }
 
 func (c *Client) UpdateHotspotOp(ctx context.Context, site string, data *HotspotOp) (*HotspotOp, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "hotspotop", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "hotspotop", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/hotspot_package.generated.go
+++ b/networkserver/hotspot_package.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type HotspotPackage struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                             *string  `json:"_id,omitempty"`
+	SiteID                         *string  `json:"site_id,omitempty"`
+	Hidden                         *bool    `json:"attr_hidden,omitempty"`
+	HiddenID                       *string  `json:"attr_hidden_id,omitempty"`
+	NoDelete                       *bool    `json:"attr_no_delete,omitempty"`
+	NoEdit                         *bool    `json:"attr_no_edit,omitempty"`
 	Amount                         *float64 `json:"amount,omitempty"`
 	ChargedAs                      *string  `json:"charged_as,omitempty"`
 	Currency                       *string  `json:"currency,omitempty"`
@@ -64,6 +62,54 @@ type HotspotPackage struct {
 	PaymentFieldsZipRequired       *bool    `json:"payment_fields_zip_required,omitempty"`
 	TrialDurationMinutes           *int64   `json:"trial_duration_minutes,omitempty"`
 	TrialReset                     *float64 `json:"trial_reset,omitempty"`
+}
+
+func (s *HotspotPackage) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *HotspotPackage) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *HotspotPackage) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *HotspotPackage) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *HotspotPackage) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *HotspotPackage) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *HotspotPackage) GetAmount() float64 {
@@ -342,7 +388,7 @@ func (c *Client) DeleteHotspotPackage(ctx context.Context, site string, id strin
 		return resp, fmt.Errorf(`unable to delete HotspotPackage: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetHotspotPackage(ctx context.Context, site, id string) (*HotspotPackage, *http.Response, error) {
@@ -387,7 +433,7 @@ func (c *Client) ListHotspotPackage(ctx context.Context, site string) ([]Hotspot
 }
 
 func (c *Client) UpdateHotspotPackage(ctx context.Context, site string, data *HotspotPackage) (*HotspotPackage, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "hotspotpackage", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "hotspotpackage", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/network_conf.generated.go
+++ b/networkserver/network_conf.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type NetworkConf struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                                            *string                              `json:"_id,omitempty"`
+	SiteID                                        *string                              `json:"site_id,omitempty"`
+	Hidden                                        *bool                                `json:"attr_hidden,omitempty"`
+	HiddenID                                      *string                              `json:"attr_hidden_id,omitempty"`
+	NoDelete                                      *bool                                `json:"attr_no_delete,omitempty"`
+	NoEdit                                        *bool                                `json:"attr_no_edit,omitempty"`
 	AutoScaleEnabled                              *bool                                `json:"auto_scale_enabled,omitempty"`
 	DhcpRelayEnabled                              *bool                                `json:"dhcp_relay_enabled,omitempty"`
 	DhcpdBootEnabled                              *bool                                `json:"dhcpd_boot_enabled,omitempty"`
@@ -267,6 +265,54 @@ type NetworkConf struct {
 	XSharedClientKey                              *string                              `json:"x_shared_client_key,omitempty"`
 	XWanPassword                                  *string                              `json:"x_wan_password,omitempty"`
 	XWireguardPrivateKey                          *string                              `json:"x_wireguard_private_key,omitempty"`
+}
+
+func (s *NetworkConf) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *NetworkConf) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *NetworkConf) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *NetworkConf) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *NetworkConf) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *NetworkConf) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *NetworkConf) GetAutoScaleEnabled() bool {
@@ -2271,7 +2317,7 @@ func (c *Client) DeleteNetworkConf(ctx context.Context, site string, id string) 
 		return resp, fmt.Errorf(`unable to delete NetworkConf: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetNetworkConf(ctx context.Context, site, id string) (*NetworkConf, *http.Response, error) {
@@ -2316,7 +2362,7 @@ func (c *Client) ListNetworkConf(ctx context.Context, site string) ([]NetworkCon
 }
 
 func (c *Client) UpdateNetworkConf(ctx context.Context, site string, data *NetworkConf) (*NetworkConf, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "networkconf", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "networkconf", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/port_conf.generated.go
+++ b/networkserver/port_conf.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type PortConf struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                            *string             `json:"_id,omitempty"`
+	SiteID                        *string             `json:"site_id,omitempty"`
+	Hidden                        *bool               `json:"attr_hidden,omitempty"`
+	HiddenID                      *string             `json:"attr_hidden_id,omitempty"`
+	NoDelete                      *bool               `json:"attr_no_delete,omitempty"`
+	NoEdit                        *bool               `json:"attr_no_edit,omitempty"`
 	Autoneg                       *bool               `json:"autoneg,omitempty"`
 	Dot1XCtrl                     *string             `json:"dot1x_ctrl,omitempty"`
 	Dot1XIdleTimeout              *float64            `json:"dot1x_idle_timeout,omitempty"`
@@ -75,6 +73,54 @@ type PortConf struct {
 	StpPortMode                   *bool               `json:"stp_port_mode,omitempty"`
 	TaggedVlanMgmt                *string             `json:"tagged_vlan_mgmt,omitempty"`
 	VoiceNetworkconfId            *string             `json:"voice_networkconf_id,omitempty"`
+}
+
+func (s *PortConf) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *PortConf) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *PortConf) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *PortConf) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *PortConf) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *PortConf) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *PortConf) GetAutoneg() bool {
@@ -579,7 +625,7 @@ func (c *Client) DeletePortConf(ctx context.Context, site string, id string) (*h
 		return resp, fmt.Errorf(`unable to delete PortConf: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetPortConf(ctx context.Context, site, id string) (*PortConf, *http.Response, error) {
@@ -624,7 +670,7 @@ func (c *Client) ListPortConf(ctx context.Context, site string) ([]PortConf, *ht
 }
 
 func (c *Client) UpdatePortConf(ctx context.Context, site string, data *PortConf) (*PortConf, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "portconf", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "portconf", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/port_forward.generated.go
+++ b/networkserver/port_forward.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type PortForward struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                 *string                      `json:"_id,omitempty"`
+	SiteID             *string                      `json:"site_id,omitempty"`
+	Hidden             *bool                        `json:"attr_hidden,omitempty"`
+	HiddenID           *string                      `json:"attr_hidden_id,omitempty"`
+	NoDelete           *bool                        `json:"attr_no_delete,omitempty"`
+	NoEdit             *bool                        `json:"attr_no_edit,omitempty"`
 	DestinationIp      *string                      `json:"destination_ip,omitempty"`
 	DestinationIps     *[]PortForwardDestinationIps `json:"destination_ips,omitempty"`
 	DstPort            *string                      `json:"dst_port,omitempty"`
@@ -49,6 +47,54 @@ type PortForward struct {
 	SrcFirewallGroupId *string                      `json:"src_firewall_group_id,omitempty"`
 	SrcLimitingEnabled *bool                        `json:"src_limiting_enabled,omitempty"`
 	SrcLimitingType    *string                      `json:"src_limiting_type,omitempty"`
+}
+
+func (s *PortForward) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *PortForward) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *PortForward) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *PortForward) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *PortForward) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *PortForward) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *PortForward) GetDestinationIp() string {
@@ -228,7 +274,7 @@ func (c *Client) DeletePortForward(ctx context.Context, site string, id string) 
 		return resp, fmt.Errorf(`unable to delete PortForward: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetPortForward(ctx context.Context, site, id string) (*PortForward, *http.Response, error) {
@@ -273,7 +319,7 @@ func (c *Client) ListPortForward(ctx context.Context, site string) ([]PortForwar
 }
 
 func (c *Client) UpdatePortForward(ctx context.Context, site string, data *PortForward) (*PortForward, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "portforward", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "portforward", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/radius_profile.generated.go
+++ b/networkserver/radius_profile.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type RadiusProfile struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                        *string                     `json:"_id,omitempty"`
+	SiteID                    *string                     `json:"site_id,omitempty"`
+	Hidden                    *bool                       `json:"attr_hidden,omitempty"`
+	HiddenID                  *string                     `json:"attr_hidden_id,omitempty"`
+	NoDelete                  *bool                       `json:"attr_no_delete,omitempty"`
+	NoEdit                    *bool                       `json:"attr_no_edit,omitempty"`
 	AccountingEnabled         *bool                       `json:"accounting_enabled,omitempty"`
 	AcctServers               *[]RadiusProfileAcctServers `json:"acct_servers,omitempty"`
 	AuthServers               *[]RadiusProfileAuthServers `json:"auth_servers,omitempty"`
@@ -53,6 +51,54 @@ type RadiusProfile struct {
 	XClientPrivateKey         *string                     `json:"x_client_private_key,omitempty"`
 	XClientPrivateKeyFilename *string                     `json:"x_client_private_key_filename,omitempty"`
 	XClientPrivateKeyPassword *string                     `json:"x_client_private_key_password,omitempty"`
+}
+
+func (s *RadiusProfile) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *RadiusProfile) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *RadiusProfile) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *RadiusProfile) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *RadiusProfile) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *RadiusProfile) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *RadiusProfile) GetAccountingEnabled() bool {
@@ -303,7 +349,7 @@ func (c *Client) DeleteRadiusProfile(ctx context.Context, site string, id string
 		return resp, fmt.Errorf(`unable to delete RadiusProfile: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetRadiusProfile(ctx context.Context, site, id string) (*RadiusProfile, *http.Response, error) {
@@ -348,7 +394,7 @@ func (c *Client) ListRadiusProfile(ctx context.Context, site string) ([]RadiusPr
 }
 
 func (c *Client) UpdateRadiusProfile(ctx context.Context, site string, data *RadiusProfile) (*RadiusProfile, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "radiusprofile", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "radiusprofile", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/routing.generated.go
+++ b/networkserver/routing.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type Routing struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                   *string `json:"_id,omitempty"`
+	SiteID               *string `json:"site_id,omitempty"`
+	Hidden               *bool   `json:"attr_hidden,omitempty"`
+	HiddenID             *string `json:"attr_hidden_id,omitempty"`
+	NoDelete             *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit               *bool   `json:"attr_no_edit,omitempty"`
 	Enabled              *bool   `json:"enabled,omitempty"`
 	GatewayDevice        *string `json:"gateway_device,omitempty"`
 	GatewayType          *string `json:"gateway_type,omitempty"`
@@ -45,6 +43,54 @@ type Routing struct {
 	StaticRouteNexthop   *string `json:"static-route_nexthop,omitempty"`
 	StaticRouteType      *string `json:"static-route_type,omitempty"`
 	Type                 *string `json:"type,omitempty"`
+}
+
+func (s *Routing) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *Routing) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *Routing) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *Routing) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *Routing) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *Routing) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *Routing) GetEnabled() bool {
@@ -171,7 +217,7 @@ func (c *Client) DeleteRouting(ctx context.Context, site string, id string) (*ht
 		return resp, fmt.Errorf(`unable to delete Routing: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetRouting(ctx context.Context, site, id string) (*Routing, *http.Response, error) {
@@ -216,7 +262,7 @@ func (c *Client) ListRouting(ctx context.Context, site string) ([]Routing, *http
 }
 
 func (c *Client) UpdateRouting(ctx context.Context, site string, data *Routing) (*Routing, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "routing", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "routing", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/schedule_task.generated.go
+++ b/networkserver/schedule_task.generated.go
@@ -27,19 +27,65 @@ import (
 )
 
 type ScheduleTask struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID              *string                       `json:"_id,omitempty"`
+	SiteID          *string                       `json:"site_id,omitempty"`
+	Hidden          *bool                         `json:"attr_hidden,omitempty"`
+	HiddenID        *string                       `json:"attr_hidden_id,omitempty"`
+	NoDelete        *bool                         `json:"attr_no_delete,omitempty"`
+	NoEdit          *bool                         `json:"attr_no_edit,omitempty"`
 	Action          *string                       `json:"action,omitempty"`
 	CronExpr        *string                       `json:"cron_expr,omitempty"`
 	ExecuteOnlyOnce *bool                         `json:"execute_only_once,omitempty"`
 	Name            *string                       `json:"name,omitempty"`
 	UpgradeTargets  *[]ScheduleTaskUpgradeTargets `json:"upgrade_targets,omitempty"`
+}
+
+func (s *ScheduleTask) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *ScheduleTask) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *ScheduleTask) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *ScheduleTask) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *ScheduleTask) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *ScheduleTask) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *ScheduleTask) GetAction() string {
@@ -138,7 +184,7 @@ func (c *Client) DeleteScheduleTask(ctx context.Context, site string, id string)
 		return resp, fmt.Errorf(`unable to delete ScheduleTask: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetScheduleTask(ctx context.Context, site, id string) (*ScheduleTask, *http.Response, error) {
@@ -183,7 +229,7 @@ func (c *Client) ListScheduleTask(ctx context.Context, site string) ([]ScheduleT
 }
 
 func (c *Client) UpdateScheduleTask(ctx context.Context, site string, data *ScheduleTask) (*ScheduleTask, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "scheduletask", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "scheduletask", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/tag.generated.go
+++ b/networkserver/tag.generated.go
@@ -27,16 +27,62 @@ import (
 )
 
 type Tag struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID          *string   `json:"_id,omitempty"`
+	SiteID      *string   `json:"site_id,omitempty"`
+	Hidden      *bool     `json:"attr_hidden,omitempty"`
+	HiddenID    *string   `json:"attr_hidden_id,omitempty"`
+	NoDelete    *bool     `json:"attr_no_delete,omitempty"`
+	NoEdit      *bool     `json:"attr_no_edit,omitempty"`
 	MemberTable *[]string `json:"member_table,omitempty"`
 	Name        *string   `json:"name,omitempty"`
+}
+
+func (s *Tag) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *Tag) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *Tag) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *Tag) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *Tag) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *Tag) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *Tag) GetMemberTable() []string {
@@ -99,7 +145,7 @@ func (c *Client) DeleteTag(ctx context.Context, site string, id string) (*http.R
 		return resp, fmt.Errorf(`unable to delete Tag: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetTag(ctx context.Context, site, id string) (*Tag, *http.Response, error) {
@@ -144,7 +190,7 @@ func (c *Client) ListTag(ctx context.Context, site string) ([]Tag, *http.Respons
 }
 
 func (c *Client) UpdateTag(ctx context.Context, site string, data *Tag) (*Tag, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "tag", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "tag", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/user.generated.go
+++ b/networkserver/user.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type User struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                            *string `json:"_id,omitempty"`
+	SiteID                        *string `json:"site_id,omitempty"`
+	Hidden                        *bool   `json:"attr_hidden,omitempty"`
+	HiddenID                      *string `json:"attr_hidden_id,omitempty"`
+	NoDelete                      *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit                        *bool   `json:"attr_no_edit,omitempty"`
 	Blocked                       *string `json:"blocked,omitempty"`
 	FixedApEnabled                *bool   `json:"fixed_ap_enabled,omitempty"`
 	FixedApMac                    *string `json:"fixed_ap_mac,omitempty"`
@@ -51,6 +49,54 @@ type User struct {
 	UsergroupId                   *string `json:"usergroup_id,omitempty"`
 	VirtualNetworkOverrideEnabled *bool   `json:"virtual_network_override_enabled,omitempty"`
 	VirtualNetworkOverrideId      *string `json:"virtual_network_override_id,omitempty"`
+}
+
+func (s *User) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *User) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *User) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *User) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *User) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *User) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *User) GetBlocked() string {
@@ -225,7 +271,7 @@ func (c *Client) DeleteUser(ctx context.Context, site string, id string) (*http.
 		return resp, fmt.Errorf(`unable to delete User: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetUser(ctx context.Context, site, id string) (*User, *http.Response, error) {
@@ -270,7 +316,7 @@ func (c *Client) ListUser(ctx context.Context, site string) ([]User, *http.Respo
 }
 
 func (c *Client) UpdateUser(ctx context.Context, site string, data *User) (*User, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "user", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "user", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/user_group.generated.go
+++ b/networkserver/user_group.generated.go
@@ -27,17 +27,63 @@ import (
 )
 
 type UserGroup struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID             *string `json:"_id,omitempty"`
+	SiteID         *string `json:"site_id,omitempty"`
+	Hidden         *bool   `json:"attr_hidden,omitempty"`
+	HiddenID       *string `json:"attr_hidden_id,omitempty"`
+	NoDelete       *bool   `json:"attr_no_delete,omitempty"`
+	NoEdit         *bool   `json:"attr_no_edit,omitempty"`
 	Name           *string `json:"name,omitempty"`
 	QosRateMaxDown *int64  `json:"qos_rate_max_down,omitempty"`
 	QosRateMaxUp   *int64  `json:"qos_rate_max_up,omitempty"`
+}
+
+func (s *UserGroup) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *UserGroup) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *UserGroup) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *UserGroup) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *UserGroup) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *UserGroup) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *UserGroup) GetName() string {
@@ -108,7 +154,7 @@ func (c *Client) DeleteUserGroup(ctx context.Context, site string, id string) (*
 		return resp, fmt.Errorf(`unable to delete UserGroup: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetUserGroup(ctx context.Context, site, id string) (*UserGroup, *http.Response, error) {
@@ -153,7 +199,7 @@ func (c *Client) ListUserGroup(ctx context.Context, site string) ([]UserGroup, *
 }
 
 func (c *Client) UpdateUserGroup(ctx context.Context, site string, data *UserGroup) (*UserGroup, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "usergroup", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "usergroup", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/wlan_conf.generated.go
+++ b/networkserver/wlan_conf.generated.go
@@ -27,14 +27,12 @@ import (
 )
 
 type WlanConf struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
-	Hidden   *bool   `json:"attr_hidden,omitempty"`
-	HiddenID *string `json:"attr_hidden_id,omitempty"`
-	NoDelete *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
-
+	ID                          *string                         `json:"_id,omitempty"`
+	SiteID                      *string                         `json:"site_id,omitempty"`
+	Hidden                      *bool                           `json:"attr_hidden,omitempty"`
+	HiddenID                    *string                         `json:"attr_hidden_id,omitempty"`
+	NoDelete                    *bool                           `json:"attr_no_delete,omitempty"`
+	NoEdit                      *bool                           `json:"attr_no_edit,omitempty"`
 	ApGroupIds                  *[]string                       `json:"ap_group_ids,omitempty"`
 	ApGroupMode                 *string                         `json:"ap_group_mode,omitempty"`
 	AuthCache                   *bool                           `json:"auth_cache,omitempty"`
@@ -125,6 +123,54 @@ type WlanConf struct {
 	XIappKey                    *string                         `json:"x_iapp_key,omitempty"`
 	XPassphrase                 *string                         `json:"x_passphrase,omitempty"`
 	XWep                        *string                         `json:"x_wep,omitempty"`
+}
+
+func (s *WlanConf) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *WlanConf) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *WlanConf) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *WlanConf) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *WlanConf) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *WlanConf) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *WlanConf) GetApGroupIds() []string {
@@ -1434,7 +1480,7 @@ func (c *Client) DeleteWlanConf(ctx context.Context, site string, id string) (*h
 		return resp, fmt.Errorf(`unable to delete WlanConf: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetWlanConf(ctx context.Context, site, id string) (*WlanConf, *http.Response, error) {
@@ -1479,7 +1525,7 @@ func (c *Client) ListWlanConf(ctx context.Context, site string) ([]WlanConf, *ht
 }
 
 func (c *Client) UpdateWlanConf(ctx context.Context, site string, data *WlanConf) (*WlanConf, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "wlanconf", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "wlanconf", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err

--- a/networkserver/wlan_group.generated.go
+++ b/networkserver/wlan_group.generated.go
@@ -27,15 +27,61 @@ import (
 )
 
 type WlanGroup struct {
-	ID     *string `json:"_id,omitempty"`
-	SiteID *string `json:"site_id,omitempty"`
-
+	ID       *string `json:"_id,omitempty"`
+	SiteID   *string `json:"site_id,omitempty"`
 	Hidden   *bool   `json:"attr_hidden,omitempty"`
 	HiddenID *string `json:"attr_hidden_id,omitempty"`
 	NoDelete *bool   `json:"attr_no_delete,omitempty"`
 	NoEdit   *bool   `json:"attr_no_edit,omitempty"`
+	Name     *string `json:"name,omitempty"`
+}
 
-	Name *string `json:"name,omitempty"`
+func (s *WlanGroup) GetID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.ID
+}
+
+func (s *WlanGroup) GetSiteID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.SiteID
+}
+
+func (s *WlanGroup) GetHidden() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.Hidden
+}
+
+func (s *WlanGroup) GetHiddenID() string {
+	if s == nil {
+		return ""
+	}
+
+	return *s.HiddenID
+}
+
+func (s *WlanGroup) GetNoDelete() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoDelete
+}
+
+func (s *WlanGroup) GetNoEdit() bool {
+	if s == nil {
+		return false
+	}
+
+	return *s.NoEdit
 }
 
 func (s *WlanGroup) GetName() string {
@@ -90,7 +136,7 @@ func (c *Client) DeleteWlanGroup(ctx context.Context, site string, id string) (*
 		return resp, fmt.Errorf(`unable to delete WlanGroup: %w`, err)
 	}
 
-	return nil, nil
+	return resp, nil
 }
 
 func (c *Client) GetWlanGroup(ctx context.Context, site, id string) (*WlanGroup, *http.Response, error) {
@@ -135,7 +181,7 @@ func (c *Client) ListWlanGroup(ctx context.Context, site string) ([]WlanGroup, *
 }
 
 func (c *Client) UpdateWlanGroup(ctx context.Context, site string, data *WlanGroup) (*WlanGroup, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "wlangroup", *data.ID)
+	endpointPath := path.Join("api/s/", site, "rest", "wlangroup", data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
When the root endpoint object fields were added, matching convenience accessors were not added. This fixes that and simplifies the rendering of the fields.