### PR TITLE
Remove generated endpoint files before rendering

### DIFF
--- a/internal/client-gen/api/endpoint.go
+++ b/internal/client-gen/api/endpoint.go
@@ -46,7 +46,7 @@ func NewEndpoint(name, file string, spec map[string]interface{}) (*Endpoint, err
 	return &Endpoint{
 		Name:           name,
 		definitionFile: file,
-		goFilePath:     strcase.ToSnake(name) + ".generated.go",
+		goFilePath:     strcase.ToSnake(name) + golangGeneratedFileSuffix,
 		rootObject:     rootObject,
 	}, nil
 }


### PR DESCRIPTION
When generating the API client it would not clean up any files that had already been created. As #12 allowed for endpoints to be configured via an external configuration file, this meant it was more likely that an endpoint was disabled and its generated file not removed.

This PR cleans up any generated files before re-rendering any endpoint files by assuming that and `.generated.go` file is safe to delete in the `networkserver` package.