### PR TITLE
Render descriptions for fields

### DIFF
--- a/internal/client-gen/api/renderer_test.go
+++ b/internal/client-gen/api/renderer_test.go
@@ -1,0 +1,52 @@
+// Copyright 2024 James Toyer
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_goDescription(t *testing.T) {
+	tests := map[string]struct {
+		description string
+		want        string
+	}{
+		"empty string": {
+			description: "",
+			want:        "",
+		},
+		"single line string": {
+			description: "A single line string",
+			want:        "// A single line string",
+		},
+		"multi line string": {
+			description: `A multi line string
+
+With some blank lines in them`,
+			want: `// A multi line string
+//
+// With some blank lines in them`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := goDescription(test.description)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/client-gen/api/templates/struct.gotmpl
+++ b/internal/client-gen/api/templates/struct.gotmpl
@@ -1,9 +1,13 @@
 type {{ .Name }} struct {
 	{{- range $field := .Fields }}
+	{{ goDescription $field.Description }}
 	{{ $field.Name }} *{{ $field.Type.GoType }} `json:"{{ $field.JSONName}},omitempty"`
 	{{- end }}
 }
 {{ range $field := .Fields }}
+// Get{{ $field.Name }} is a helper function which dereferences {{ $field.Name }}.
+//
+// When {{ $field.Name }} is a nil pointer it will return `{{ $field.Type.DefaultValue }}` as default.
 func (s *{{ $.Name }}) Get{{ $field.Name }}() {{ if $field.Type.IsObjectType }}*{{ end }}{{ $field.Type.GoType }} {
 	if s == nil {{ if not $field.Type.IsPrimitiveType }}|| s.{{ $field.Name}} == nil {{ end }}{
 		return {{ $field.Type.DefaultValue }}

--- a/networkserver/user.generated.go
+++ b/networkserver/user.generated.go
@@ -27,30 +27,99 @@ import (
 )
 
 type User struct {
-	ID                            *string `json:"_id,omitempty"`
-	SiteID                        *string `json:"site_id,omitempty"`
-	Hidden                        *bool   `json:"attr_hidden,omitempty"`
-	HiddenID                      *string `json:"attr_hidden_id,omitempty"`
-	NoDelete                      *bool   `json:"attr_no_delete,omitempty"`
-	NoEdit                        *bool   `json:"attr_no_edit,omitempty"`
-	Blocked                       *string `json:"blocked,omitempty"`
-	FixedAPEnabled                *bool   `json:"fixed_ap_enabled,omitempty"`
-	FixedAPMac                    *string `json:"fixed_ap_mac,omitempty"`
-	FixedAPIP                     *string `json:"fixed_ip,omitempty"`
-	Hostname                      *string `json:"hostname,omitempty"`
-	LastSeen                      *string `json:"last_seen,omitempty"`
-	LocalDNSRecord                *string `json:"local_dns_record,omitempty"`
-	LocalDNSRecordEnabled         *bool   `json:"local_dns_record_enabled,omitempty"`
-	MAC                           *string `json:"mac,omitempty"`
-	Name                          *string `json:"name,omitempty"`
-	NetworkID                     *string `json:"network_id,omitempty"`
-	Note                          *string `json:"note,omitempty"`
-	UseFixedIP                    *bool   `json:"use_fixedip,omitempty"`
-	UserGroupID                   *string `json:"usergroup_id,omitempty"`
-	VirtualNetworkOverrideEnabled *bool   `json:"virtual_network_override_enabled,omitempty"`
-	VirtualNetworkOverrideID      *string `json:"virtual_network_override_id,omitempty"`
+	// ID has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	ID *string `json:"_id,omitempty"`
+	// SiteID has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	SiteID *string `json:"site_id,omitempty"`
+	// Hidden has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	Hidden *bool `json:"attr_hidden,omitempty"`
+	// HiddenID has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	HiddenID *string `json:"attr_hidden_id,omitempty"`
+	// NoDelete has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	NoDelete *bool `json:"attr_no_delete,omitempty"`
+	// NoEdit has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	NoEdit *bool `json:"attr_no_edit,omitempty"`
+	// Blocked has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	Blocked *string `json:"blocked,omitempty"`
+	// FixedAPEnabled has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: false|true
+	FixedAPEnabled *bool `json:"fixed_ap_enabled,omitempty"`
+	// FixedAPMac has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+	FixedAPMac *string `json:"fixed_ap_mac,omitempty"`
+	// FixedAPIP has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	FixedAPIP *string `json:"fixed_ip,omitempty"`
+	// Hostname has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	Hostname *string `json:"hostname,omitempty"`
+	// LastSeen has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	LastSeen *string `json:"last_seen,omitempty"`
+	// LocalDNSRecord has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	LocalDNSRecord *string `json:"local_dns_record,omitempty"`
+	// LocalDNSRecordEnabled has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: false|true
+	LocalDNSRecordEnabled *bool `json:"local_dns_record_enabled,omitempty"`
+	// MAC has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: ^([0-9A-Fa-f]{2}:){5}([0-9A-Fa-f]{2})$
+	MAC *string `json:"mac,omitempty"`
+	// Name has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	Name *string `json:"name,omitempty"`
+	// NetworkID has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	NetworkID *string `json:"network_id,omitempty"`
+	// Note has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	Note *string `json:"note,omitempty"`
+	// UseFixedIP has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: false|true
+	UseFixedIP *bool `json:"use_fixedip,omitempty"`
+	// UserGroupID has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	UserGroupID *string `json:"usergroup_id,omitempty"`
+	// VirtualNetworkOverrideEnabled has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: false|true
+	VirtualNetworkOverrideEnabled *bool `json:"virtual_network_override_enabled,omitempty"`
+	// VirtualNetworkOverrideID has been auto generated from the Unifi Network Server API specification
+	//
+	// Validation: None
+	VirtualNetworkOverrideID *string `json:"virtual_network_override_id,omitempty"`
 }
 
+// GetID is a helper function which dereferences ID.
+//
+// When ID is a nil pointer it will return `""` as default.
 func (s *User) GetID() string {
 	if s == nil {
 		return ""
@@ -59,6 +128,9 @@ func (s *User) GetID() string {
 	return *s.ID
 }
 
+// GetSiteID is a helper function which dereferences SiteID.
+//
+// When SiteID is a nil pointer it will return `""` as default.
 func (s *User) GetSiteID() string {
 	if s == nil {
 		return ""
@@ -67,6 +139,9 @@ func (s *User) GetSiteID() string {
 	return *s.SiteID
 }
 
+// GetHidden is a helper function which dereferences Hidden.
+//
+// When Hidden is a nil pointer it will return `false` as default.
 func (s *User) GetHidden() bool {
 	if s == nil {
 		return false
@@ -75,6 +150,9 @@ func (s *User) GetHidden() bool {
 	return *s.Hidden
 }
 
+// GetHiddenID is a helper function which dereferences HiddenID.
+//
+// When HiddenID is a nil pointer it will return `""` as default.
 func (s *User) GetHiddenID() string {
 	if s == nil {
 		return ""
@@ -83,6 +161,9 @@ func (s *User) GetHiddenID() string {
 	return *s.HiddenID
 }
 
+// GetNoDelete is a helper function which dereferences NoDelete.
+//
+// When NoDelete is a nil pointer it will return `false` as default.
 func (s *User) GetNoDelete() bool {
 	if s == nil {
 		return false
@@ -91,6 +172,9 @@ func (s *User) GetNoDelete() bool {
 	return *s.NoDelete
 }
 
+// GetNoEdit is a helper function which dereferences NoEdit.
+//
+// When NoEdit is a nil pointer it will return `false` as default.
 func (s *User) GetNoEdit() bool {
 	if s == nil {
 		return false
@@ -99,6 +183,9 @@ func (s *User) GetNoEdit() bool {
 	return *s.NoEdit
 }
 
+// GetBlocked is a helper function which dereferences Blocked.
+//
+// When Blocked is a nil pointer it will return `""` as default.
 func (s *User) GetBlocked() string {
 	if s == nil {
 		return ""
@@ -107,6 +194,9 @@ func (s *User) GetBlocked() string {
 	return *s.Blocked
 }
 
+// GetFixedAPEnabled is a helper function which dereferences FixedAPEnabled.
+//
+// When FixedAPEnabled is a nil pointer it will return `false` as default.
 func (s *User) GetFixedAPEnabled() bool {
 	if s == nil {
 		return false
@@ -115,6 +205,9 @@ func (s *User) GetFixedAPEnabled() bool {
 	return *s.FixedAPEnabled
 }
 
+// GetFixedAPMac is a helper function which dereferences FixedAPMac.
+//
+// When FixedAPMac is a nil pointer it will return `""` as default.
 func (s *User) GetFixedAPMac() string {
 	if s == nil {
 		return ""
@@ -123,6 +216,9 @@ func (s *User) GetFixedAPMac() string {
 	return *s.FixedAPMac
 }
 
+// GetFixedAPIP is a helper function which dereferences FixedAPIP.
+//
+// When FixedAPIP is a nil pointer it will return `""` as default.
 func (s *User) GetFixedAPIP() string {
 	if s == nil {
 		return ""
@@ -131,6 +227,9 @@ func (s *User) GetFixedAPIP() string {
 	return *s.FixedAPIP
 }
 
+// GetHostname is a helper function which dereferences Hostname.
+//
+// When Hostname is a nil pointer it will return `""` as default.
 func (s *User) GetHostname() string {
 	if s == nil {
 		return ""
@@ -139,6 +238,9 @@ func (s *User) GetHostname() string {
 	return *s.Hostname
 }
 
+// GetLastSeen is a helper function which dereferences LastSeen.
+//
+// When LastSeen is a nil pointer it will return `""` as default.
 func (s *User) GetLastSeen() string {
 	if s == nil {
 		return ""
@@ -147,6 +249,9 @@ func (s *User) GetLastSeen() string {
 	return *s.LastSeen
 }
 
+// GetLocalDNSRecord is a helper function which dereferences LocalDNSRecord.
+//
+// When LocalDNSRecord is a nil pointer it will return `""` as default.
 func (s *User) GetLocalDNSRecord() string {
 	if s == nil {
 		return ""
@@ -155,6 +260,9 @@ func (s *User) GetLocalDNSRecord() string {
 	return *s.LocalDNSRecord
 }
 
+// GetLocalDNSRecordEnabled is a helper function which dereferences LocalDNSRecordEnabled.
+//
+// When LocalDNSRecordEnabled is a nil pointer it will return `false` as default.
 func (s *User) GetLocalDNSRecordEnabled() bool {
 	if s == nil {
 		return false
@@ -163,6 +271,9 @@ func (s *User) GetLocalDNSRecordEnabled() bool {
 	return *s.LocalDNSRecordEnabled
 }
 
+// GetMAC is a helper function which dereferences MAC.
+//
+// When MAC is a nil pointer it will return `""` as default.
 func (s *User) GetMAC() string {
 	if s == nil {
 		return ""
@@ -171,6 +282,9 @@ func (s *User) GetMAC() string {
 	return *s.MAC
 }
 
+// GetName is a helper function which dereferences Name.
+//
+// When Name is a nil pointer it will return `""` as default.
 func (s *User) GetName() string {
 	if s == nil {
 		return ""
@@ -179,6 +293,9 @@ func (s *User) GetName() string {
 	return *s.Name
 }
 
+// GetNetworkID is a helper function which dereferences NetworkID.
+//
+// When NetworkID is a nil pointer it will return `""` as default.
 func (s *User) GetNetworkID() string {
 	if s == nil {
 		return ""
@@ -187,6 +304,9 @@ func (s *User) GetNetworkID() string {
 	return *s.NetworkID
 }
 
+// GetNote is a helper function which dereferences Note.
+//
+// When Note is a nil pointer it will return `""` as default.
 func (s *User) GetNote() string {
 	if s == nil {
 		return ""
@@ -195,6 +315,9 @@ func (s *User) GetNote() string {
 	return *s.Note
 }
 
+// GetUseFixedIP is a helper function which dereferences UseFixedIP.
+//
+// When UseFixedIP is a nil pointer it will return `false` as default.
 func (s *User) GetUseFixedIP() bool {
 	if s == nil {
 		return false
@@ -203,6 +326,9 @@ func (s *User) GetUseFixedIP() bool {
 	return *s.UseFixedIP
 }
 
+// GetUserGroupID is a helper function which dereferences UserGroupID.
+//
+// When UserGroupID is a nil pointer it will return `""` as default.
 func (s *User) GetUserGroupID() string {
 	if s == nil {
 		return ""
@@ -211,6 +337,9 @@ func (s *User) GetUserGroupID() string {
 	return *s.UserGroupID
 }
 
+// GetVirtualNetworkOverrideEnabled is a helper function which dereferences VirtualNetworkOverrideEnabled.
+//
+// When VirtualNetworkOverrideEnabled is a nil pointer it will return `false` as default.
 func (s *User) GetVirtualNetworkOverrideEnabled() bool {
 	if s == nil {
 		return false
@@ -219,6 +348,9 @@ func (s *User) GetVirtualNetworkOverrideEnabled() bool {
 	return *s.VirtualNetworkOverrideEnabled
 }
 
+// GetVirtualNetworkOverrideID is a helper function which dereferences VirtualNetworkOverrideID.
+//
+// When VirtualNetworkOverrideID is a nil pointer it will return `""` as default.
 func (s *User) GetVirtualNetworkOverrideID() string {
 	if s == nil {
 		return ""


### PR DESCRIPTION
Render the `Description` on a `Field` as part of the Go struct. Additionally, add some descriptions to the helper functions which deference the field values.