### PR TITLE
Return nil for Get requests to missing entities

### DIFF
--- a/internal/client-gen/api/templates/file.gotmpl
+++ b/internal/client-gen/api/templates/file.gotmpl
@@ -36,17 +36,17 @@ func (c *Client) Create{{ .Name }}(ctx context.Context, site string, data *{{ .N
         return nil, resp, fmt.Errorf(`unable to create {{ .ResourcePath }}: %w`, err)
     }
 
-    var item {{ .Name }}
+    var item *{{ .Name }}
     switch len(body.Payload) {
     case 0:
         err = errors.New(`failed to create {{ .Name }}`)
     case 1:
-        item = body.Payload[0]
+        item = &body.Payload[0]
     default:
         err = fmt.Errorf("unexpected number of results: %v", len(body.Payload))
     }
 
-    return &item, resp, err
+    return item, resp, err
 }
 
 func (c *Client) Delete{{ .Name }}(ctx context.Context, site string, id string) (*http.Response, error) {

--- a/networkserver/user.generated.go
+++ b/networkserver/user.generated.go
@@ -377,17 +377,17 @@ func (c *Client) CreateUser(ctx context.Context, site string, data *User) (*User
 		return nil, resp, fmt.Errorf(`unable to create user: %w`, err)
 	}
 
-	var item User
+	var item *User
 	switch len(body.Payload) {
 	case 0:
 		err = errors.New(`failed to create User`)
 	case 1:
-		item = body.Payload[0]
+		item = &body.Payload[0]
 	default:
 		err = fmt.Errorf("unexpected number of results: %v", len(body.Payload))
 	}
 
-	return &item, resp, err
+	return item, resp, err
 }
 
 func (c *Client) DeleteUser(ctx context.Context, site string, id string) (*http.Response, error) {


### PR DESCRIPTION
Previously Get requests would return not return `nil` when there the requested entity did not exists. This happened because the definition for found entity was a value and not a pointed, e.g. `var item User`. The behaviour here thus makes it difficult to validate if a user was actually found or not.

The fix was to make the entity a reference and return that.