### PR TITLE
Make site a client option

### DIFF
--- a/internal/client-gen/api/templates/file.gotmpl
+++ b/internal/client-gen/api/templates/file.gotmpl
@@ -23,9 +23,8 @@ type responseBody{{ .Name }} struct {
 	Payload  []{{ .Name }}   `json:"data"`
 }
 
-func (c *Client) Create{{ .Name }}(ctx context.Context, site string, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
-    endpointPath := path.Join("api/s/", site, "rest", "{{ .ResourcePath }}")
-    req, err := c.NewRequest(ctx, http.MethodPost, endpointPath, data)
+func (c *Client) Create{{ .Name }}(ctx context.Context, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
+    req, err := c.NewRequest(ctx, http.MethodPost, c.ResourceAPIPath("{{ .ResourcePath }}"), data)
     if err != nil {
         return nil, nil, err
     }
@@ -49,8 +48,8 @@ func (c *Client) Create{{ .Name }}(ctx context.Context, site string, data *{{ .N
     return item, resp, err
 }
 
-func (c *Client) Delete{{ .Name }}(ctx context.Context, site string, id string) (*http.Response, error) {
-    endpointPath:= path.Join("api/s/",site, "rest", "{{ .ResourcePath }}", id)
+func (c *Client) Delete{{ .Name }}(ctx context.Context, id string) (*http.Response, error) {
+    endpointPath:= path.Join(c.ResourceAPIPath("{{ .ResourcePath }}"), id)
     req, err := c.NewRequest(ctx, http.MethodDelete, endpointPath, nil)
     if err != nil {
         return nil, err
@@ -65,8 +64,8 @@ func (c *Client) Delete{{ .Name }}(ctx context.Context, site string, id string) 
     return resp, nil
 }
 
-func (c *Client) Get{{ .Name }}(ctx context.Context, site, id string) (*{{ .Name }}, *http.Response, error) {
-	endpointPath:= path.Join("api/s/",site, "rest", "{{ .ResourcePath }}", id)
+func (c *Client) Get{{ .Name }}(ctx context.Context, id string) (*{{ .Name }}, *http.Response, error) {
+	endpointPath:= path.Join(c.ResourceAPIPath("{{ .ResourcePath }}"), id)
     req, err := c.NewRequest(ctx, http.MethodGet, endpointPath, nil)
     if err != nil {
         return nil, nil, err
@@ -90,9 +89,8 @@ func (c *Client) Get{{ .Name }}(ctx context.Context, site, id string) (*{{ .Name
 	return &item, resp, err
 }
 
-func (c *Client) List{{ .Name }}(ctx context.Context, site string) ([]{{ .Name }}, *http.Response, error) {
-    endpointPath:= path.Join("api/s/",site, "rest", "{{ .ResourcePath }}")
-    req, err := c.NewRequest(ctx, http.MethodGet, endpointPath, nil)
+func (c *Client) List{{ .Name }}(ctx context.Context) ([]{{ .Name }}, *http.Response, error) {
+    req, err := c.NewRequest(ctx, http.MethodGet, c.ResourceAPIPath("{{ .ResourcePath }}"), nil)
     if err != nil {
         return nil, nil, err
     }
@@ -106,8 +104,8 @@ func (c *Client) List{{ .Name }}(ctx context.Context, site string) ([]{{ .Name }
     return body.Payload, resp, nil
 }
 
-func (c *Client) Update{{ .Name }}(ctx context.Context, site string, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
-    endpointPath:= path.Join("api/s/",site, "rest", "{{ .ResourcePath }}", data.GetID())
+func (c *Client) Update{{ .Name }}(ctx context.Context, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
+    endpointPath:= path.Join(c.ResourceAPIPath("{{ .ResourcePath }}"), data.GetID())
     req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
     if err != nil {
         return nil, nil, err

--- a/networkserver/client.go
+++ b/networkserver/client.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"path"
 	"strings"
 	"sync"
 	"time"
@@ -69,13 +70,14 @@ type Client struct {
 	endpoint     *url.URL
 	username     string
 	password     string
+	site         string
 
 	csrf     string
 	csrfLock sync.RWMutex
 }
 
 // NewClient creates a new Unifi Network Server client.
-func NewClient(ctx context.Context, endpoint, username, password string, options ...ClientOption) (*Client, error) {
+func NewClient(ctx context.Context, endpoint, username, password, site string, options ...ClientOption) (*Client, error) {
 	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint: %w", err)
@@ -96,6 +98,7 @@ func NewClient(ctx context.Context, endpoint, username, password string, options
 		endpoint: u,
 		username: username,
 		password: password,
+		site:     site,
 	}
 
 	if err = client.initialise(ctx); err != nil {
@@ -103,6 +106,11 @@ func NewClient(ctx context.Context, endpoint, username, password string, options
 	}
 
 	return client, nil
+}
+
+// ResourceAPIPath generates the correct API path for a given resource that can be used with NewRequest.
+func (c *Client) ResourceAPIPath(resource string) string {
+	return path.Join("api/s/", c.site, "rest", resource)
 }
 
 func (c *Client) NewRequest(ctx context.Context, method, urlPath string, body interface{}) (*http.Request, error) {

--- a/networkserver/client_test.go
+++ b/networkserver/client_test.go
@@ -40,7 +40,7 @@ func (suite *ClientIntegrationTestSuite) SetupSuite() {
 
 	suite.unifiContainer = container
 
-	client, err := NewClient(ctx, suite.unifiContainer.Endpoint, "admin", "admin",
+	client, err := NewClient(ctx, suite.unifiContainer.Endpoint, "admin", "admin", "default",
 		WithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 	)
 	if err != nil {

--- a/networkserver/user.generated.go
+++ b/networkserver/user.generated.go
@@ -364,9 +364,8 @@ type responseBodyUser struct {
 	Payload  []User          `json:"data"`
 }
 
-func (c *Client) CreateUser(ctx context.Context, site string, data *User) (*User, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "user")
-	req, err := c.NewRequest(ctx, http.MethodPost, endpointPath, data)
+func (c *Client) CreateUser(ctx context.Context, data *User) (*User, *http.Response, error) {
+	req, err := c.NewRequest(ctx, http.MethodPost, c.ResourceAPIPath("user"), data)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -390,8 +389,8 @@ func (c *Client) CreateUser(ctx context.Context, site string, data *User) (*User
 	return item, resp, err
 }
 
-func (c *Client) DeleteUser(ctx context.Context, site string, id string) (*http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "user", id)
+func (c *Client) DeleteUser(ctx context.Context, id string) (*http.Response, error) {
+	endpointPath := path.Join(c.ResourceAPIPath("user"), id)
 	req, err := c.NewRequest(ctx, http.MethodDelete, endpointPath, nil)
 	if err != nil {
 		return nil, err
@@ -406,8 +405,8 @@ func (c *Client) DeleteUser(ctx context.Context, site string, id string) (*http.
 	return resp, nil
 }
 
-func (c *Client) GetUser(ctx context.Context, site, id string) (*User, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "user", id)
+func (c *Client) GetUser(ctx context.Context, id string) (*User, *http.Response, error) {
+	endpointPath := path.Join(c.ResourceAPIPath("user"), id)
 	req, err := c.NewRequest(ctx, http.MethodGet, endpointPath, nil)
 	if err != nil {
 		return nil, nil, err
@@ -431,9 +430,8 @@ func (c *Client) GetUser(ctx context.Context, site, id string) (*User, *http.Res
 	return &item, resp, err
 }
 
-func (c *Client) ListUser(ctx context.Context, site string) ([]User, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "user")
-	req, err := c.NewRequest(ctx, http.MethodGet, endpointPath, nil)
+func (c *Client) ListUser(ctx context.Context) ([]User, *http.Response, error) {
+	req, err := c.NewRequest(ctx, http.MethodGet, c.ResourceAPIPath("user"), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -447,8 +445,8 @@ func (c *Client) ListUser(ctx context.Context, site string) ([]User, *http.Respo
 	return body.Payload, resp, nil
 }
 
-func (c *Client) UpdateUser(ctx context.Context, site string, data *User) (*User, *http.Response, error) {
-	endpointPath := path.Join("api/s/", site, "rest", "user", data.GetID())
+func (c *Client) UpdateUser(ctx context.Context, data *User) (*User, *http.Response, error) {
+	endpointPath := path.Join(c.ResourceAPIPath("user"), data.GetID())
 	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
The site was previously being set on each request which added a lot of duplication when running multiple commands, especially as is likely to not change in general use. Now the site has been moved to the client, which means a new client is required per site, but reduces the duplication that happens on each function invocation.