### PR TITLE
Fix create and update error messages

### DIFF
--- a/internal/client-gen/api/templates/file.gotmpl
+++ b/internal/client-gen/api/templates/file.gotmpl
@@ -33,7 +33,7 @@ func (c *Client) Create{{ .Name }}(ctx context.Context, site string, data *{{ .N
     var body responseBody{{ .Name }}
     resp, err := c.Do(ctx, req, &body)
     if err != nil {
-        return nil, resp, fmt.Errorf(`unable to create {{ .ResourcePath }}: %w`, err)
+        return nil, resp, fmt.Errorf(`unable to create {{ .Name }}: %w`, err)
     }
 
     var item *{{ .Name }}
@@ -116,7 +116,7 @@ func (c *Client) Update{{ .Name }}(ctx context.Context, site string, data *{{ .N
     var body responseBody{{ .Name }}
     resp, err := c.Do(ctx, req, &body)
     if err != nil {
-        return nil, resp, fmt.Errorf(`unable to update {{ .ResourcePath }}: %w`, err)
+        return nil, resp, fmt.Errorf(`unable to update {{ .Name }}: %w`, err)
     }
 
     var item {{ .Name }}

--- a/networkserver/user.generated.go
+++ b/networkserver/user.generated.go
@@ -374,7 +374,7 @@ func (c *Client) CreateUser(ctx context.Context, site string, data *User) (*User
 	var body responseBodyUser
 	resp, err := c.Do(ctx, req, &body)
 	if err != nil {
-		return nil, resp, fmt.Errorf(`unable to create user: %w`, err)
+		return nil, resp, fmt.Errorf(`unable to create User: %w`, err)
 	}
 
 	var item *User
@@ -457,7 +457,7 @@ func (c *Client) UpdateUser(ctx context.Context, site string, data *User) (*User
 	var body responseBodyUser
 	resp, err := c.Do(ctx, req, &body)
 	if err != nil {
-		return nil, resp, fmt.Errorf(`unable to update user: %w`, err)
+		return nil, resp, fmt.Errorf(`unable to update User: %w`, err)
 	}
 
 	var item User


### PR DESCRIPTION
This makes all the auto generated error messages consistent. Are these error messages "right"? Probably not but at least the generation is now the same for all of them.