### PR TITLE
Correctly return nil when no entity is found

### DIFF
--- a/internal/client-gen/api/templates/file.gotmpl
+++ b/internal/client-gen/api/templates/file.gotmpl
@@ -77,16 +77,16 @@ func (c *Client) Get{{ .Name }}(ctx context.Context, id string) (*{{ .Name }}, *
 		return nil, resp, fmt.Errorf(`unable to get {{ .Name }}: %w`, err)
     }
 
-	var item {{ .Name }}
+	var item *{{ .Name }}
 	switch len(body.Payload) {
 	case 0:
     case 1:
-		item = body.Payload[0]
+		item = &body.Payload[0]
     default:
 		err = fmt.Errorf("unexpected number of results: %v", len(body.Payload))
     }
 
-	return &item, resp, err
+	return item, resp, err
 }
 
 func (c *Client) List{{ .Name }}(ctx context.Context) ([]{{ .Name }}, *http.Response, error) {
@@ -117,15 +117,15 @@ func (c *Client) Update{{ .Name }}(ctx context.Context, data *{{ .Name }}) (*{{ 
         return nil, resp, fmt.Errorf(`unable to update {{ .Name }}: %w`, err)
     }
 
-    var item {{ .Name }}
+    var item *{{ .Name }}
     switch len(body.Payload) {
     case 0:
         err = errors.New(`failed to update {{ .Name }}`)
     case 1:
-        item = body.Payload[0]
+        item = &body.Payload[0]
     default:
         err = fmt.Errorf("unexpected number of results: %v", len(body.Payload))
     }
 
-    return &item, resp, err
+    return item, resp, err
 }

--- a/networkserver/user.generated.go
+++ b/networkserver/user.generated.go
@@ -418,16 +418,16 @@ func (c *Client) GetUser(ctx context.Context, id string) (*User, *http.Response,
 		return nil, resp, fmt.Errorf(`unable to get User: %w`, err)
 	}
 
-	var item User
+	var item *User
 	switch len(body.Payload) {
 	case 0:
 	case 1:
-		item = body.Payload[0]
+		item = &body.Payload[0]
 	default:
 		err = fmt.Errorf("unexpected number of results: %v", len(body.Payload))
 	}
 
-	return &item, resp, err
+	return item, resp, err
 }
 
 func (c *Client) ListUser(ctx context.Context) ([]User, *http.Response, error) {
@@ -458,15 +458,15 @@ func (c *Client) UpdateUser(ctx context.Context, data *User) (*User, *http.Respo
 		return nil, resp, fmt.Errorf(`unable to update User: %w`, err)
 	}
 
-	var item User
+	var item *User
 	switch len(body.Payload) {
 	case 0:
 		err = errors.New(`failed to update User`)
 	case 1:
-		item = body.Payload[0]
+		item = &body.Payload[0]
 	default:
 		err = fmt.Errorf("unexpected number of results: %v", len(body.Payload))
 	}
 
-	return &item, resp, err
+	return item, resp, err
 }


### PR DESCRIPTION
Contrary to what #24 claims to have fixed it didn't actually do it. Instead this PR fixes the nil responses, not only for Get but for Update too.