### PR TITLE
Allow endpoint actions to be disabled

### DIFF
--- a/internal/client-gen/api/overrides.go
+++ b/internal/client-gen/api/overrides.go
@@ -39,7 +39,9 @@ func ApplyOverrides(endpoints []*spec.Endpoint, overrides Overrides) []*spec.End
 }
 
 type EndpointOverrides struct {
-	Name         *string                     `yaml:"name,omitempty"`
+	Name *string `yaml:"name,omitempty"`
+
+	Actions      *EndpointActionsOverrides   `yaml:"actions,omitempty"`
 	Objects      map[string]*ObjectOverrides `yaml:"objects,omitempty"`
 	ResourcePath *string                     `yaml:"resourcePath,omitempty"`
 }
@@ -72,7 +74,44 @@ func ApplyEndpointOverrides(endpoint *spec.Endpoint, overrides *EndpointOverride
 	}
 
 	ep.Objects = objects
+	ep.Actions = applyActionsOverrides(ep.Actions, overrides.Actions)
 	return &ep
+}
+
+type EndpointActionsOverrides struct {
+	DisableCreate *bool `yaml:"disableCreate,omitempty"`
+	DisableDelete *bool `yaml:"disableDelete,omitempty"`
+	DisableGet    *bool `yaml:"disableGet,omitempty"`
+	DisableList   *bool `yaml:"disableList,omitempty"`
+	DisableUpdate *bool `yaml:"disableUpdate,omitempty"`
+}
+
+func applyActionsOverrides(actions spec.EndpointActions, overrides *EndpointActionsOverrides) spec.EndpointActions {
+	if overrides == nil {
+		return actions
+	}
+
+	if overrides.DisableCreate != nil {
+		actions.DisableCreate = *overrides.DisableCreate
+	}
+
+	if overrides.DisableDelete != nil {
+		actions.DisableDelete = *overrides.DisableDelete
+	}
+
+	if overrides.DisableGet != nil {
+		actions.DisableGet = *overrides.DisableGet
+	}
+
+	if overrides.DisableList != nil {
+		actions.DisableList = *overrides.DisableList
+	}
+
+	if overrides.DisableUpdate != nil {
+		actions.DisableUpdate = *overrides.DisableUpdate
+	}
+
+	return actions
 }
 
 type ObjectOverrides struct {

--- a/internal/client-gen/api/overrides_test.go
+++ b/internal/client-gen/api/overrides_test.go
@@ -174,6 +174,46 @@ func TestApplyEndpointOverrides(t *testing.T) {
 				},
 			},
 		},
+		"actions are empty": {
+			endpoint: &spec.Endpoint{
+				Name:         "ActionsOverride",
+				ResourcePath: "actions",
+			},
+			overrides: &EndpointOverrides{
+				Actions: &EndpointActionsOverrides{},
+			},
+			want: &spec.Endpoint{
+				Name:         "ActionsOverride",
+				ResourcePath: "actions",
+			},
+		},
+		"actions are overridden": {
+			endpoint: &spec.Endpoint{
+				Name:         "ActionsOverride",
+				ResourcePath: "actions",
+			},
+			overrides: &EndpointOverrides{
+				Name: networkserver.String("Updated"),
+				Actions: &EndpointActionsOverrides{
+					DisableCreate: networkserver.Bool(true),
+					DisableDelete: networkserver.Bool(true),
+					DisableGet:    networkserver.Bool(true),
+					DisableList:   networkserver.Bool(true),
+					DisableUpdate: networkserver.Bool(true),
+				},
+			},
+			want: &spec.Endpoint{
+				Name:         "Updated",
+				ResourcePath: "actions",
+				Actions: spec.EndpointActions{
+					DisableCreate: true,
+					DisableDelete: true,
+					DisableGet:    true,
+					DisableList:   true,
+					DisableUpdate: true,
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/internal/client-gen/api/renderer.go
+++ b/internal/client-gen/api/renderer.go
@@ -60,11 +60,13 @@ func (r *Renderer) RenderEndpoint(ctx context.Context, endpoint *spec.Endpoint, 
 
 	var buffer bytes.Buffer
 	templateContent := struct {
+		Actions      spec.EndpointActions
 		Name         string
 		Objects      []*spec.Object
 		PackageName  string
 		ResourcePath string
 	}{
+		Actions:      endpoint.Actions,
 		Name:         endpoint.Name,
 		Objects:      endpoint.Objects,
 		PackageName:  packageName,

--- a/internal/client-gen/api/templates/file.gotmpl
+++ b/internal/client-gen/api/templates/file.gotmpl
@@ -17,12 +17,12 @@ import (
 {{ template "struct.gotmpl" $struct }}
 {{ end }}
 
-
 type responseBody{{ .Name }} struct {
     Metadata json.RawMessage `json:"meta"`
 	Payload  []{{ .Name }}   `json:"data"`
 }
 
+{{ if not .Actions.DisableCreate }}
 func (c *Client) Create{{ .Name }}(ctx context.Context, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
     req, err := c.NewRequest(ctx, http.MethodPost, c.ResourceAPIPath("{{ .ResourcePath }}"), data)
     if err != nil {
@@ -47,7 +47,9 @@ func (c *Client) Create{{ .Name }}(ctx context.Context, data *{{ .Name }}) (*{{ 
 
     return item, resp, err
 }
+{{ end }}
 
+{{ if not .Actions.DisableDelete }}
 func (c *Client) Delete{{ .Name }}(ctx context.Context, id string) (*http.Response, error) {
     endpointPath:= path.Join(c.ResourceAPIPath("{{ .ResourcePath }}"), id)
     req, err := c.NewRequest(ctx, http.MethodDelete, endpointPath, nil)
@@ -63,7 +65,9 @@ func (c *Client) Delete{{ .Name }}(ctx context.Context, id string) (*http.Respon
 
     return resp, nil
 }
+{{ end }}
 
+{{ if not .Actions.DisableGet }}
 func (c *Client) Get{{ .Name }}(ctx context.Context, id string) (*{{ .Name }}, *http.Response, error) {
 	endpointPath:= path.Join(c.ResourceAPIPath("{{ .ResourcePath }}"), id)
     req, err := c.NewRequest(ctx, http.MethodGet, endpointPath, nil)
@@ -88,7 +92,9 @@ func (c *Client) Get{{ .Name }}(ctx context.Context, id string) (*{{ .Name }}, *
 
 	return item, resp, err
 }
+{{ end }}
 
+{{ if not .Actions.DisableList }}
 func (c *Client) List{{ .Name }}(ctx context.Context) ([]{{ .Name }}, *http.Response, error) {
     req, err := c.NewRequest(ctx, http.MethodGet, c.ResourceAPIPath("{{ .ResourcePath }}"), nil)
     if err != nil {
@@ -103,7 +109,9 @@ func (c *Client) List{{ .Name }}(ctx context.Context) ([]{{ .Name }}, *http.Resp
 
     return body.Payload, resp, nil
 }
+{{ end }}
 
+{{ if not .Actions.DisableUpdate }}
 func (c *Client) Update{{ .Name }}(ctx context.Context, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
     endpointPath:= path.Join(c.ResourceAPIPath("{{ .ResourcePath }}"), data.GetID())
     req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, data)
@@ -129,3 +137,4 @@ func (c *Client) Update{{ .Name }}(ctx context.Context, data *{{ .Name }}) (*{{ 
 
     return item, resp, err
 }
+{{ end }}

--- a/internal/client-gen/spec/endpoint.go
+++ b/internal/client-gen/spec/endpoint.go
@@ -22,9 +22,18 @@ import (
 	"github.com/iancoleman/strcase"
 )
 
+type EndpointActions struct {
+	DisableCreate bool
+	DisableDelete bool
+	DisableGet    bool
+	DisableList   bool
+	DisableUpdate bool
+}
+
 type Endpoint struct {
 	Name string
 
+	Actions      EndpointActions
 	Filename     string
 	Objects      []*Object
 	ResourcePath string


### PR DESCRIPTION
There are times when the default generated actions are not sufficient and will not perform as expected. This is normally down to the API having a different way of performing that actions. For example, to disable a user the MAC address must be used and a completely different endpoint called to execute this.

Rather than encode the logic for custom actions in to the spec, this PR allows for them to be disable allowing the actions to be implemented in a custom way elsewhere.