### PR TITLE
Switch to using UnmarshalText on FieldType

### DIFF
--- a/internal/client-gen/spec/field_type.go
+++ b/internal/client-gen/spec/field_type.go
@@ -15,10 +15,9 @@
 package spec
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"gopkg.in/yaml.v3"
 )
 
 var (
@@ -82,11 +81,12 @@ func (t *FieldType) ElementType() *FieldType {
 	return nil
 }
 
-func (t *FieldType) UnmarshalYAML(node *yaml.Node) error {
-	var value string
-	if err := node.Decode(&value); err != nil {
-		return fmt.Errorf("failed to unmarshal field type: %w", err)
+func (t *FieldType) UnmarshalText(text []byte) error {
+	if text == nil {
+		return errors.New("text must not be nil")
 	}
+
+	value := strings.TrimSpace(string(text))
 
 	ft := unmarshalFieldType(value)
 	*t = ft

--- a/internal/client-gen/spec/field_type_test.go
+++ b/internal/client-gen/spec/field_type_test.go
@@ -18,77 +18,76 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"gopkg.in/yaml.v3"
 )
 
-func TestFieldType_UnmarshalYAML(t *testing.T) {
+func TestFieldType_UnmarshalText(t *testing.T) {
 	tests := map[string]struct {
-		data    string
+		data    []byte
 		want    FieldType
 		wantErr assert.ErrorAssertionFunc
 	}{
 		"data is empty": {
-			data:    "",
+			data:    []byte(""),
 			want:    unknownType,
 			wantErr: assert.Error,
 		},
 		"data is invalid YAML": {
-			data:    "'",
+			data:    []byte("'"),
 			want:    unknownType,
 			wantErr: assert.Error,
 		},
 		"data is a string": {
-			data:    "String",
+			data:    []byte("String"),
 			want:    FieldTypeString,
 			wantErr: assert.NoError,
 		},
 		"data is a boolean": {
-			data:    "Boolean",
+			data:    []byte("Boolean"),
 			want:    FieldTypeBoolean,
 			wantErr: assert.NoError,
 		},
 		"data is a number": {
-			data:    "Number",
+			data:    []byte("Number"),
 			want:    FieldTypeNumber,
 			wantErr: assert.NoError,
 		},
 		"data is a decimal": {
-			data:    "Decimal",
+			data:    []byte("Decimal"),
 			want:    FieldTypeDecimal,
 			wantErr: assert.NoError,
 		},
 		"data is a list": {
-			data:    "List(String)",
+			data:    []byte("List(String)"),
 			want:    FieldTypeList(FieldTypeString),
 			wantErr: assert.NoError,
 		},
 		"data is an object": {
-			data:    "Object(AnObject)",
+			data:    []byte("Object(AnObject)"),
 			want:    FieldTypeObject("AnObject"),
 			wantErr: assert.NoError,
 		},
 		"data is a list of object": {
-			data:    "List(Object(Nested))",
+			data:    []byte("List(Object(Nested))"),
 			want:    FieldTypeList(FieldTypeObject("Nested")),
 			wantErr: assert.NoError,
 		},
 		"data is missing trailing list bracket": {
-			data:    "List(String",
+			data:    []byte("List(String"),
 			want:    unknownType,
 			wantErr: assert.Error,
 		},
 		"data is missing trailing object bracket": {
-			data:    "Object(String",
+			data:    []byte("Object(String"),
 			want:    unknownType,
 			wantErr: assert.Error,
 		},
 		"data is missing trailing nested bracket": {
-			data:    "List(Object(String)",
+			data:    []byte("List(Object(String)"),
 			want:    unknownType,
 			wantErr: assert.Error,
 		},
 		"data is invalid type": {
-			data:    "Not a real type",
+			data:    []byte("Not a real type"),
 			want:    unknownType,
 			wantErr: assert.Error,
 		},
@@ -97,7 +96,7 @@ func TestFieldType_UnmarshalYAML(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			got := FieldType{}
-			err := got.UnmarshalYAML(&yaml.Node{Value: test.data, Kind: yaml.ScalarNode})
+			err := got.UnmarshalText(test.data)
 			test.wantErr(t, err)
 			assert.Equal(t, test.want, got)
 		})


### PR DESCRIPTION
The spec package had dependency on the `yaml.v3` package in order to unmarshal its values. However, that meant it only support YAML and not any other form of unmarshalling and also ensure the `spec` package had a hard dependency on `yaml.v3`. 

This PR switches to using the `encoding` package, and specifically the `UnmarshalText`, for unmarshalling values which means it can now support other encoders, e.g. JSON, without needing to depend on them.