### PR TITLE
Allow client devices to retrieved by mac address

### DIFF
--- a/internal/client-gen/config.yml
+++ b/internal/client-gen/config.yml
@@ -31,6 +31,10 @@ apiOverrides:
             VirtualNetworkOverrideId:
               name: VirtualNetworkOverrideID
           additionalFields:
+            CurrentIP:
+              description: |
+                The CurrentIP address assigned to the ClientDevice. This is read only and will only be populated when
+                a request to GetByMAC is made.
             "DeviceIDOverride":
               description: |
                 The DeviceIDOverride allows for the type of client device to be overridden, which subsequently changes 

--- a/networkserver/client.go
+++ b/networkserver/client.go
@@ -107,9 +107,14 @@ func NewClient(ctx context.Context, endpoint, username, password, site string, o
 	return client, nil
 }
 
-// ResourceAPIPath generates the correct API path for a given resource that can be used with NewRequest.
+// ResourceAPIPath generates the correct API path for a given rest resource that can be used with NewRequest.
 func (c *Client) ResourceAPIPath(resource string) string {
 	return path.Join(apiV1Path, "s", c.site, "rest", resource)
+}
+
+// StatAPIPath generates the correct API path for a given stat resource that can be used with NewRequest.
+func (c *Client) StatAPIPath(resource string) string {
+	return path.Join(apiV1Path, "s", c.site, "stat", resource)
 }
 
 func (c *Client) NewRequest(ctx context.Context, method, urlPath string, body interface{}) (*http.Request, error) {

--- a/networkserver/client_device.generated.go
+++ b/networkserver/client_device.generated.go
@@ -115,6 +115,9 @@ type ClientDevice struct {
 	//
 	// Validation: None
 	VirtualNetworkOverrideID *string `json:"virtual_network_override_id,omitempty"`
+	// The CurrentIP address assigned to the ClientDevice. This is read only and will only be populated when
+	// a request to GetByMAC is made.
+	CurrentIP *string `json:"current_ip,omitempty"`
 	// The DeviceIDOverride allows for the type of client device to be overridden, which subsequently changes
 	// which icon the client device is displayed with in the UI.
 	DeviceIDOverride *int64 `json:"dev_id_override,omitempty"`
@@ -360,6 +363,17 @@ func (s *ClientDevice) GetVirtualNetworkOverrideID() string {
 	}
 
 	return *s.VirtualNetworkOverrideID
+}
+
+// GetCurrentIP is a helper function which dereferences CurrentIP.
+//
+// When CurrentIP is a nil pointer it will return `""` as default.
+func (s *ClientDevice) GetCurrentIP() string {
+	if s == nil || s.CurrentIP == nil {
+		return ""
+	}
+
+	return *s.CurrentIP
 }
 
 // GetDeviceIDOverride is a helper function which dereferences DeviceIDOverride.

--- a/networkserver/client_device_test.go
+++ b/networkserver/client_device_test.go
@@ -238,6 +238,38 @@ func (suite *ClientIntegrationTestSuite) TestClient_Update() {
 	})
 }
 
+func (suite *ClientIntegrationTestSuite) TestClient_GetByMAC() {
+	t := suite.T()
+	t.Run("get existing client device", func(t *testing.T) {
+		ctx := context.Background()
+		mac, _ := suite.macPool.MAC()
+
+		wantName := "get client device" + time.Now().String()
+		newClientDevice := suite.createClientDevice(ctx, t, &ClientDevice{
+			Name: String(wantName),
+			MAC:  String(mac.String()),
+		})
+
+		got, _, err := suite.client.ClientDevices.GetByMAC(ctx, mac.String())
+		assert.NoError(t, err)
+		assert.NotNil(t, got)
+		assert.NotEmpty(t, got.GetID())
+		assert.Equal(t, wantName, got.GetName())
+		assert.Equal(t, mac.String(), got.GetMAC())
+		assert.Equal(t, newClientDevice.GetID(), got.GetID())
+	})
+
+	t.Run("get non existent client device", func(t *testing.T) {
+		ctx := context.Background()
+		mac, release := suite.macPool.MAC()
+		defer release()
+
+		got, _, err := suite.client.ClientDevices.Get(ctx, mac.String())
+		assert.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
 func (suite *ClientIntegrationTestSuite) TestClient_Block() {
 	t := suite.T()
 	t.Run("block client device", func(t *testing.T) {


### PR DESCRIPTION
The `Get` endpoint does not return all the information expected about a client device, most notably the current IP address of it. Additionally, the UI makes it super hard to find the ID of a client device, however the MAC address is very visible and is easier use in many cases when making a lookup.