### PR TITLE
Preserve HTTP responses on error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,6 @@ linters:
     - revive
     - sloglint
     - stylecheck
-    - testifylint
     - unconvert
     - unused
     - whitespace
@@ -23,5 +22,7 @@ linters:
 linters-settings:
   wrapcheck:
     ignorePackageGlobs:
-      - github.com/jamestoyer/go-unifi-network-server/*
+      - context
       - log/slog
+
+      - github.com/jamestoyer/go-unifi-network-server/*

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - revive
     - sloglint
     - stylecheck
+    - testifylint
     - unconvert
     - unused
     - whitespace

--- a/internal/client-gen/api/templates/service.gotmpl
+++ b/internal/client-gen/api/templates/service.gotmpl
@@ -26,7 +26,7 @@ type responseBody{{ .Name }} struct {
 
 {{ if not .Actions.DisableCreate }}
 func (s *{{ .Name }}Service) Create(ctx context.Context, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
-    req, err := s.NewRequest(ctx, http.MethodPost, s.ResourceAPIPath("{{ .ResourcePath }}"), data)
+    req, err := s.NewRequest(http.MethodPost, s.ResourceAPIPath("{{ .ResourcePath }}"), data)
     if err != nil {
         return nil, nil, err
     }
@@ -54,7 +54,7 @@ func (s *{{ .Name }}Service) Create(ctx context.Context, data *{{ .Name }}) (*{{
 {{ if not .Actions.DisableDelete }}
 func (s *{{ .Name }}Service) Delete(ctx context.Context, id string) (*http.Response, error) {
     endpointPath:= path.Join(s.ResourceAPIPath("{{ .ResourcePath }}"), id)
-    req, err := s.NewRequest(ctx, http.MethodDelete, endpointPath, nil)
+    req, err := s.NewRequest(http.MethodDelete, endpointPath, nil)
     if err != nil {
         return nil, err
     }
@@ -72,7 +72,7 @@ func (s *{{ .Name }}Service) Delete(ctx context.Context, id string) (*http.Respo
 {{ if not .Actions.DisableGet }}
 func (s *{{ .Name }}Service) Get(ctx context.Context, id string) (*{{ .Name }}, *http.Response, error) {
 	endpointPath:= path.Join(s.ResourceAPIPath("{{ .ResourcePath }}"), id)
-    req, err := s.NewRequest(ctx, http.MethodGet, endpointPath, nil)
+    req, err := s.NewRequest(http.MethodGet, endpointPath, nil)
     if err != nil {
         return nil, nil, err
     }
@@ -98,7 +98,7 @@ func (s *{{ .Name }}Service) Get(ctx context.Context, id string) (*{{ .Name }}, 
 
 {{ if not .Actions.DisableList }}
 func (s *{{ .Name }}Service) List(ctx context.Context) ([]{{ .Name }}, *http.Response, error) {
-    req, err := s.NewRequest(ctx, http.MethodGet, s.ResourceAPIPath("{{ .ResourcePath }}"), nil)
+    req, err := s.NewRequest(http.MethodGet, s.ResourceAPIPath("{{ .ResourcePath }}"), nil)
     if err != nil {
         return nil, nil, err
     }
@@ -116,7 +116,7 @@ func (s *{{ .Name }}Service) List(ctx context.Context) ([]{{ .Name }}, *http.Res
 {{ if not .Actions.DisableUpdate }}
 func (s *{{ .Name }}Service) Update(ctx context.Context, data *{{ .Name }}) (*{{ .Name }}, *http.Response, error) {
     endpointPath:= path.Join(s.ResourceAPIPath("{{ .ResourcePath }}"), data.GetID())
-    req, err := s.NewRequest(ctx, http.MethodPut, endpointPath, data)
+    req, err := s.NewRequest(http.MethodPut, endpointPath, data)
     if err != nil {
         return nil, nil, err
     }

--- a/networkserver/client.go
+++ b/networkserver/client.go
@@ -370,17 +370,18 @@ type ErrResponse struct {
 		ResponseCode string `json:"rc"`
 		Message      string `json:"msg"`
 	} `json:"meta"`
-	Data     interface{} `json:"data"`
-	response *http.Response
+	Data interface{} `json:"data"`
+
+	Response *http.Response `json:"-"`
 }
 
 func (e *ErrResponse) Error() string {
-	if e.response != nil && e.response.Request != nil {
-		return fmt.Sprintf("%v %v: %d %s %+v", e.response.Request.Method, e.response.Request.URL, e.response.StatusCode, e.Meta.Message, e.Data)
+	if e.Response != nil && e.Response.Request != nil {
+		return fmt.Sprintf("%v %v: %d %s %+v", e.Response.Request.Method, e.Response.Request.URL, e.Response.StatusCode, e.Meta.Message, e.Data)
 	}
 
-	if e.response != nil {
-		return fmt.Sprintf("%d %s %+v", e.response.StatusCode, e.Meta.Message, e.Data)
+	if e.Response != nil {
+		return fmt.Sprintf("%d %s %+v", e.Response.StatusCode, e.Meta.Message, e.Data)
 	}
 
 	return fmt.Sprintf("%s %+v", e.Meta.Message, e.Data)
@@ -391,7 +392,7 @@ func checkResponseForError(resp *http.Response) error {
 		return nil
 	}
 
-	errResp := &ErrResponse{response: resp}
+	errResp := &ErrResponse{Response: resp}
 	data, err := io.ReadAll(resp.Body)
 	if err == nil && data != nil {
 		if err = json.Unmarshal(data, errResp); err != nil {

--- a/networkserver/client.go
+++ b/networkserver/client.go
@@ -412,7 +412,7 @@ func checkResponseForError(resp *http.Response) error {
 	if err == nil && data != nil {
 		if err = json.Unmarshal(data, errResp); err != nil {
 			// Reset the response to ensure we don't leave it in an inconsistent state after the failed unmarshalling
-			errResp = &ErrResponse{}
+			errResp = &ErrResponse{Response: resp}
 		}
 	}
 

--- a/networkserver/client_config.go
+++ b/networkserver/client_config.go
@@ -19,8 +19,9 @@ import (
 )
 
 type ClientConfig struct {
-	TLSConfig *tls.Config
-	UserAgent string
+	PreserveResponseBody bool
+	TLSConfig            *tls.Config
+	UserAgent            string
 }
 
 type ClientOption interface {

--- a/networkserver/client_device.generated.go
+++ b/networkserver/client_device.generated.go
@@ -395,7 +395,7 @@ type responseBodyClientDevice struct {
 }
 
 func (s *ClientDeviceService) Create(ctx context.Context, data *ClientDevice) (*ClientDevice, *http.Response, error) {
-	req, err := s.NewRequest(ctx, http.MethodPost, s.ResourceAPIPath("user"), data)
+	req, err := s.NewRequest(http.MethodPost, s.ResourceAPIPath("user"), data)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -421,7 +421,7 @@ func (s *ClientDeviceService) Create(ctx context.Context, data *ClientDevice) (*
 
 func (s *ClientDeviceService) Get(ctx context.Context, id string) (*ClientDevice, *http.Response, error) {
 	endpointPath := path.Join(s.ResourceAPIPath("user"), id)
-	req, err := s.NewRequest(ctx, http.MethodGet, endpointPath, nil)
+	req, err := s.NewRequest(http.MethodGet, endpointPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -445,7 +445,7 @@ func (s *ClientDeviceService) Get(ctx context.Context, id string) (*ClientDevice
 }
 
 func (s *ClientDeviceService) List(ctx context.Context) ([]ClientDevice, *http.Response, error) {
-	req, err := s.NewRequest(ctx, http.MethodGet, s.ResourceAPIPath("user"), nil)
+	req, err := s.NewRequest(http.MethodGet, s.ResourceAPIPath("user"), nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -461,7 +461,7 @@ func (s *ClientDeviceService) List(ctx context.Context) ([]ClientDevice, *http.R
 
 func (s *ClientDeviceService) Update(ctx context.Context, data *ClientDevice) (*ClientDevice, *http.Response, error) {
 	endpointPath := path.Join(s.ResourceAPIPath("user"), data.GetID())
-	req, err := s.NewRequest(ctx, http.MethodPut, endpointPath, data)
+	req, err := s.NewRequest(http.MethodPut, endpointPath, data)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/networkserver/client_device.go
+++ b/networkserver/client_device.go
@@ -42,7 +42,7 @@ func (c *Client) Delete(ctx context.Context, mac string) (*http.Response, error)
 // unlike Get which doesn't include this.
 func (s *ClientDeviceService) GetByMAC(ctx context.Context, mac string) (*ClientDevice, *http.Response, error) {
 	endpointPath := path.Join(s.StatAPIPath("user"), mac)
-	req, err := s.NewRequest(ctx, http.MethodGet, endpointPath, nil)
+	req, err := s.NewRequest(http.MethodGet, endpointPath, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -115,7 +115,7 @@ func (c *Client) OverrideDeviceID(ctx context.Context, mac string, fingerprint i
 		MAC:              mac,
 	}
 
-	req, err := c.NewRequest(ctx, http.MethodPut, endpointPath, f)
+	req, err := c.NewRequest(http.MethodPut, endpointPath, f)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (c *Client) OverrideDeviceID(ctx context.Context, mac string, fingerprint i
 
 func (c *Client) RemoveDeviceIDOverride(ctx context.Context, mac string) (*http.Response, error) {
 	endpointPath := path.Join(apiV2Path, "site", c.site, "station", mac, "fingerprint_override")
-	req, err := c.NewRequest(ctx, http.MethodDelete, endpointPath, nil)
+	req, err := c.NewRequest(http.MethodDelete, endpointPath, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When an error occurs it is useful to have the HTTP response body in order to find out what might have gone wrong. Whilst `ErrResponse` included the decoded body this was not exposed. Furthermore, if there was a JSON decoding error it was impossible to find out what the original response was to see why the unmarshal failed.

This PR improves the handling of errors by ensuring the response is accessible, along with its body, when there is an error from the server. It also introduces `ErrJSONUnmarshal` which also includes the response and its body, allowing the original values to be compared and interrogated.